### PR TITLE
fix(designer): prevent Form Settings autocomplete runtime crash

### DIFF
--- a/web/src/designer/components/form-settings.tsx
+++ b/web/src/designer/components/form-settings.tsx
@@ -282,9 +282,7 @@ export const FormSettingsPanel = ({viewSetId}: {viewSetId: string}) => {
               getOptionLabel={option => option.label}
               renderInput={params => (
                 <DebouncedTextField
-                  onChange={function (): void {
-                    throw new Error('Function not implemented.');
-                  }}
+                  onChange={() => {}}
                   {...params}
                   InputProps={{
                     ...params.InputProps,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## JIRA Ticket

N/A

## Description

Prevent a runtime exception in the Designer Form Settings panel when using the Summary Fields autocomplete input.

## Proposed Changes

- Replaced the placeholder throwing `onChange` handler in `web/src/designer/components/form-settings.tsx` with a safe no-op callback for the Summary Fields autocomplete render input.
- Kept the change minimal and scoped to the reported crash path.

## How to Test

1. Open the designer and navigate to a form.
2. Open **Form Settings**.
3. In **Summary Fields**, click/type in the autocomplete input.
4. Confirm there is no runtime exception and interaction continues normally.

## Additional Information

- This change intentionally addresses only the reported high-severity runtime exception.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3a6280d-4c19-4de7-85ef-c03fc5e79929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3a6280d-4c19-4de7-85ef-c03fc5e79929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

