### PR TITLE
feat(web): highlight public templates and add catalogue visibility filter

### DIFF
--- a/web/src/components/data-table/data-table.tsx
+++ b/web/src/components/data-table/data-table.tsx
@@ -20,13 +20,18 @@ import {useState, ReactNode} from 'react';
 import {DataTablePagination} from './pagination';
 import {Input} from '@/components/ui/input';
 import {Skeleton} from '@/components/ui/skeleton';
+import {cn} from '@/lib/utils';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data?: TData[];
   loading?: boolean;
   button?: ReactNode;
+  /** Renders after the global filter input (e.g. secondary filters). */
+  toolbarExtra?: ReactNode;
   onRowClick?: (row: TData) => void;
+  /** Merged into each body row; use for conditional row styling. */
+  getRowClassName?: (row: TData) => string | undefined;
   defaultRowsPerPage?: number;
 }
 
@@ -41,7 +46,9 @@ export function DataTable<TData, TValue>({
   data,
   loading,
   button,
+  toolbarExtra,
   onRowClick,
+  getRowClassName,
   defaultRowsPerPage = 10,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -77,6 +84,7 @@ export function DataTable<TData, TValue>({
           onChange={event => table.setGlobalFilter(event.target.value)}
           className="max-w-sm"
         />
+        {toolbarExtra}
         {button}
       </div>
 
@@ -129,7 +137,10 @@ export function DataTable<TData, TValue>({
               table.getRowModel().rows.map(row => (
                 <TableRow
                   key={row.id}
-                  className={onRowClick ? 'cursor-pointer' : ''}
+                  className={cn(
+                    onRowClick && 'cursor-pointer',
+                    getRowClassName?.(row.original)
+                  )}
                   data-state={row.getIsSelected() && 'selected'}
                   onClick={() => onRowClick && onRowClick(row.original)}
                 >

--- a/web/src/components/data-table/data-table.tsx
+++ b/web/src/components/data-table/data-table.tsx
@@ -79,7 +79,7 @@ export function DataTable<TData, TValue>({
     <div className="flex flex-col gap-2">
       <div className="flex justify-start items-center gap-4">
         <Input
-          placeholder="Search results..."
+          placeholder="Search..."
           value={table.getState().globalFilter || ''}
           onChange={event => table.setGlobalFilter(event.target.value)}
           className="max-w-sm"

--- a/web/src/components/data-table/data-table.tsx
+++ b/web/src/components/data-table/data-table.tsx
@@ -79,7 +79,7 @@ export function DataTable<TData, TValue>({
     <div className="flex flex-col gap-2">
       <div className="flex justify-start items-center gap-4">
         <Input
-          placeholder="Filter results..."
+          placeholder="Search results..."
           value={table.getState().globalFilter || ''}
           onChange={event => table.setGlobalFilter(event.target.value)}
           className="max-w-sm"

--- a/web/src/components/tables/template-visibility-filter.tsx
+++ b/web/src/components/tables/template-visibility-filter.tsx
@@ -24,7 +24,7 @@ export function filterTemplatesByVisibility<T extends {isPublic?: boolean}>(
 
 /** Subtle row tint for catalogue-public templates in list tables. */
 export const PUBLIC_TEMPLATE_ROW_CLASS =
-  'bg-emerald-500/[0.06] hover:bg-emerald-500/[0.11] dark:bg-emerald-500/[0.11] dark:hover:bg-emerald-500/[0.17]';
+  'bg-accented-row/[0.035] hover:bg-accented-row/[0.07] dark:bg-accented-row/[0.06] dark:hover:bg-accented-row/[0.1]';
 
 export function TemplateVisibilityFilterSelect({
   value,

--- a/web/src/components/tables/template-visibility-filter.tsx
+++ b/web/src/components/tables/template-visibility-filter.tsx
@@ -1,0 +1,54 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+export type TemplateVisibilityFilterValue = 'all' | 'public' | 'private';
+
+export function filterTemplatesByVisibility<T extends {isPublic?: boolean}>(
+  templates: T[] | undefined,
+  filter: TemplateVisibilityFilterValue
+): T[] {
+  const list = templates ?? [];
+  if (filter === 'all') {
+    return list;
+  }
+  if (filter === 'public') {
+    return list.filter(t => t.isPublic === true);
+  }
+  return list.filter(t => t.isPublic !== true);
+}
+
+/** Subtle row tint for catalogue-public templates in list tables. */
+export const PUBLIC_TEMPLATE_ROW_CLASS =
+  'bg-emerald-500/[0.06] hover:bg-emerald-500/[0.11] dark:bg-emerald-500/[0.11] dark:hover:bg-emerald-500/[0.17]';
+
+export function TemplateVisibilityFilterSelect({
+  value,
+  onValueChange,
+}: {
+  value: TemplateVisibilityFilterValue;
+  onValueChange: (next: TemplateVisibilityFilterValue) => void;
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={v => onValueChange(v as TemplateVisibilityFilterValue)}
+    >
+      <SelectTrigger
+        className="w-[11rem]"
+        aria-label="Filter by catalogue visibility"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All templates</SelectItem>
+        <SelectItem value="public">Public only</SelectItem>
+        <SelectItem value="private">Private only</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/web/src/components/tables/templates.tsx
+++ b/web/src/components/tables/templates.tsx
@@ -63,7 +63,7 @@ const visibilityColumn: ColumnDef<Column> = {
       <RoleCard
         className={cn(
           isPublic &&
-            'border border-emerald-200/70 bg-emerald-50/90 text-emerald-900 dark:border-emerald-800/55 dark:bg-emerald-950/40 dark:text-emerald-50'
+            'border border-accented-row/25 bg-accented-row/[0.12] text-accented-row dark:border-accented-row/35 dark:bg-accented-row/[0.18] dark:text-accented-row'
         )}
       >
         {label}

--- a/web/src/components/tables/templates.tsx
+++ b/web/src/components/tables/templates.tsx
@@ -1,6 +1,7 @@
 import {ColumnDef} from '@tanstack/react-table';
 import {DataTableColumnHeader} from '../data-table/column-header';
 import {RoleCard} from '../ui/role-card';
+import {cn} from '@/lib/utils';
 import {TeamCellComponent} from './cells/team-cell';
 import {NOTEBOOK_NAME_CAPITALIZED} from '@/constants';
 import {
@@ -14,17 +15,13 @@ export type Column = any;
 
 const nameColumn: ColumnDef<Column> = {
   accessorKey: 'name',
-  header: ({column}) => (
-    <DataTableColumnHeader column={column} title="Name" />
-  ),
+  header: ({column}) => <DataTableColumnHeader column={column} title="Name" />,
 };
 
 const teamColumn: ColumnDef<Column> = {
   id: 'team',
   accessorKey: 'ownedByTeamId',
-  header: ({column}) => (
-    <DataTableColumnHeader column={column} title="Team" />
-  ),
+  header: ({column}) => <DataTableColumnHeader column={column} title="Team" />,
   cell: ({
     row: {
       original: {ownedByTeamId, ownedByTeamDisplayName},
@@ -60,8 +57,18 @@ const visibilityColumn: ColumnDef<Column> = {
   accessorFn: (row: Column & {isPublic?: boolean}) =>
     row.isPublic === true ? 'Public' : 'Private',
   cell: ({row}: {row: {original: Column & {isPublic?: boolean}}}) => {
-    const label = row.original.isPublic === true ? 'Public' : 'Private';
-    return <RoleCard>{label}</RoleCard>;
+    const isPublic = row.original.isPublic === true;
+    const label = isPublic ? 'Public' : 'Private';
+    return (
+      <RoleCard
+        className={cn(
+          isPublic &&
+            'border border-emerald-200/70 bg-emerald-50/90 text-emerald-900 dark:border-emerald-800/55 dark:bg-emerald-950/40 dark:text-emerald-50'
+        )}
+      >
+        {label}
+      </RoleCard>
+    );
   },
 };
 

--- a/web/src/components/tabs/teams/team-templates.tsx
+++ b/web/src/components/tabs/teams/team-templates.tsx
@@ -1,16 +1,31 @@
 import {DataTable} from '@/components/data-table/data-table';
+import type {ColumnDef} from '@tanstack/react-table';
 import {CreateTemplateDialog} from '@/components/dialogs/create-template-dialog';
 import {getTemplatesTableColumns} from '@/components/tables/templates';
 import {useAuth} from '@/context/auth-provider';
 import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
 import {useGetTemplatesForTeam} from '@/hooks/queries';
-import {Action, globalRolesGrantAction} from '@faims3/data-model';
+import {
+  Action,
+  globalRolesGrantAction,
+  type GetListTemplatesResponse,
+} from '@faims3/data-model';
 import {useNavigate} from '@tanstack/react-router';
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
+import {
+  filterTemplatesByVisibility,
+  PUBLIC_TEMPLATE_ROW_CLASS,
+  TemplateVisibilityFilterSelect,
+  type TemplateVisibilityFilterValue,
+} from '@/components/tables/template-visibility-filter';
+
+type TemplateListRow = GetListTemplatesResponse['templates'][number];
 
 const TeamTemplates = ({teamId}: {teamId: string}) => {
   const {user} = useAuth();
   const {isPending, data} = useGetTemplatesForTeam({user, teamId});
+  const [visibilityFilter, setVisibilityFilter] =
+    useState<TemplateVisibilityFilterValue>('all');
 
   // can the user see the add button?
   const canAddTemplateInTeam = useIsAuthorisedTo({
@@ -36,11 +51,25 @@ const TeamTemplates = ({teamId}: {teamId: string}) => {
     [user?.decodedToken]
   );
 
+  const filteredTemplates = useMemo(
+    () => filterTemplatesByVisibility(data?.templates, visibilityFilter),
+    [data?.templates, visibilityFilter]
+  );
+
   return (
     <DataTable
-      columns={columns}
-      data={data?.templates || []}
+      columns={columns as ColumnDef<TemplateListRow, unknown>[]}
+      data={filteredTemplates}
       loading={isPending}
+      toolbarExtra={
+        <TemplateVisibilityFilterSelect
+          value={visibilityFilter}
+          onValueChange={setVisibilityFilter}
+        />
+      }
+      getRowClassName={(row: TemplateListRow) =>
+        row.isPublic === true ? PUBLIC_TEMPLATE_ROW_CLASS : undefined
+      }
       onRowClick={({_id}) => navigate({to: `/templates/${_id}`})}
       button={
         canAddTemplateInTeam && <CreateTemplateDialog specifiedTeam={teamId} />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -37,6 +37,8 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    /* Listings public-template row and badge accent (HSL channels, no hsl() wrapper). */
+    --accented-row: 158 52% 34%;
   }
 
   :root,
@@ -52,6 +54,7 @@
     --primary-foreground: 0 0% 98%;
     --secondary: 173 58% 39%;
     --secondary-foreground: 0 0% 98%;
+    --accented-row: 180 50% 36%;
   }
 
   .dark {
@@ -87,6 +90,11 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --accented-row: 158 45% 58%;
+  }
+
+  .dark.theme-bss {
+    --accented-row: 173 40% 56%;
   }
 }
 

--- a/web/src/routes/_protected/templates/index.tsx
+++ b/web/src/routes/_protected/templates/index.tsx
@@ -1,17 +1,27 @@
 import {createFileRoute, useNavigate} from '@tanstack/react-router';
+import type {ColumnDef} from '@tanstack/react-table';
 import {DataTable} from '@/components/data-table/data-table';
 import {getTemplatesTableColumns} from '@/components/tables/templates';
 import {useAuth} from '@/context/auth-provider';
 import {useGetTemplates} from '@/hooks/queries';
 import {CreateTemplateDialog} from '@/components/dialogs/create-template-dialog';
 import {useBreadcrumbUpdate} from '@/hooks/use-breadcrumbs';
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
+import {
+  filterTemplatesByVisibility,
+  PUBLIC_TEMPLATE_ROW_CLASS,
+  TemplateVisibilityFilterSelect,
+  type TemplateVisibilityFilterValue,
+} from '@/components/tables/template-visibility-filter';
 import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
 import {
   Action,
   getUserResourcesForAction,
   globalRolesGrantAction,
+  type GetListTemplatesResponse,
 } from '@faims3/data-model';
+
+type TemplateListRow = GetListTemplatesResponse['templates'][number];
 
 export const Route = createFileRoute('/_protected/templates/')({
   component: RouteComponent,
@@ -27,6 +37,8 @@ function RouteComponent() {
   const {user} = useAuth();
   const {isPending, data} = useGetTemplates({user});
   const navigate = useNavigate();
+  const [visibilityFilter, setVisibilityFilter] =
+    useState<TemplateVisibilityFilterValue>('all');
 
   // can they create templates outside team?
   const canCreateGlobally = useIsAuthorisedTo({
@@ -70,13 +82,27 @@ function RouteComponent() {
     [user?.decodedToken]
   );
 
+  const filteredTemplates = useMemo(
+    () => filterTemplatesByVisibility(data, visibilityFilter),
+    [data, visibilityFilter]
+  );
+
   return (
     <div className="flex flex-col gap-6">
       <h1 className="text-2xl font-semibold tracking-tight">Templates</h1>
       <DataTable
-        columns={columns}
-        data={data}
+        columns={columns as ColumnDef<TemplateListRow, unknown>[]}
+        data={filteredTemplates}
         loading={isPending}
+        toolbarExtra={
+          <TemplateVisibilityFilterSelect
+            value={visibilityFilter}
+            onValueChange={setVisibilityFilter}
+          />
+        }
+        getRowClassName={(row: TemplateListRow) =>
+          row.isPublic === true ? PUBLIC_TEMPLATE_ROW_CLASS : undefined
+        }
         onRowClick={({_id}) => navigate({to: `/templates/${_id}`})}
         button={
           (canCreateGlobally || canCreateInSomeTeam) && <CreateTemplateDialog />

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -43,6 +43,7 @@ export default {
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
+        'accented-row': 'hsl(var(--accented-row) / <alpha-value>)',
         chart: {
           1: 'hsl(var(--chart-1))',
           2: 'hsl(var(--chart-2))',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# feat(web): highlight public templates and add catalogue visibility filter

## JIRA Ticket

N/A (UI enhancement; link ticket if one exists).

## Description

Improves the templates list so catalogue-public templates are easier to spot at a glance, and adds an optional filter for public versus private templates.

## Proposed Changes

- **Data table**: Optional `toolbarExtra` slot (after the text filter) and optional `getRowClassName` for per-row classes.
- **Templates table**: Public rows use a subtle emerald row tint; the Visibility column uses a distinct badge style for **Public** versus **Private** (when that column is shown for users who may change catalogue visibility).
- **Filter**: New dropdown on the main Templates page and the team Templates tab: **All templates** (default), **Public only**, or **Private only**. Implemented in `template-visibility-filter.tsx` with a small filter helper.

## How to Test

1. Open **Templates** (`/templates`) as a user with templates; confirm public templates have a light green row tint and (if you have visibility permissions) a green-tinted Public badge.
2. Use the visibility dropdown: **All templates** shows everything; **Public only** / **Private only** narrow the list correctly.
3. Open a team, **Templates** tab; repeat filter and row styling checks.

## Additional Information

Column definitions remain typed as `any` in `getTemplatesTableColumns`; the route components cast columns when paired with strongly typed list rows from `@faims3/data-model`.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5b5643a-3077-4b31-b44a-a6aecdc949d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5b5643a-3077-4b31-b44a-a6aecdc949d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

