### PR TITLE
feat(cdk): wire migrateNotebooksOnStartup to MIGRATE_NOTEBOOKS_ON_STARTUP

### DIFF
--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -109,7 +109,8 @@
       "scaleInCooldown": 300,
       "scaleOutCooldown": 60
     },
-    "localhostWhitelist": false
+    "localhostWhitelist": false,
+    "migrateNotebooksOnStartup": false
   },
   "authProviders": {
     "disableLocalLogin": false,

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -261,6 +261,9 @@ export class FaimsConductor extends Construct {
         AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
         NEW_CONDUCTOR_URL: props.webUrl,
         PROVISION_SSO_USERS_POLICY: props.config.provisionSSOUsersPolicy,
+        MIGRATE_NOTEBOOKS_ON_STARTUP: props.config.migrateNotebooksOnStartup
+          ? 'true'
+          : 'false',
 
         // Bugsnag (optional)
         ...(props.bugsnagApiKey ? {BUGSNAG_API_KEY: props.bugsnagApiKey} : {}),

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -435,6 +435,9 @@ const ConductorConfigSchema = z.object({
   /** Allow localhost typical addresses in the redirects for conductor? NOT
    * recommended for production use cases (for security reasons). */
   localhostWhitelist: z.boolean().default(false),
+  /** When true, sets MIGRATE_NOTEBOOKS_ON_STARTUP so the API runs notebook DB
+   * migrations on startup. */
+  migrateNotebooksOnStartup: z.boolean().default(false),
 });
 
 const WebConfigSchema = z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## JIRA Ticket

N/A (infrastructure wiring for existing API env var).

## Description

After syncing with upstream `FAIMS/FAIMS3` `main`, `MIGRATE_NOTEBOOKS_ON_STARTUP` was only available via local `.env` / container overrides; it was not part of the CDK JSON config or the Conductor ECS task environment. This change exposes it on the `conductor` section of the stack config and passes it through to the API container.

## Proposed Changes

- Add optional `conductor.migrateNotebooksOnStartup` to the Zod schema (`ConductorConfigSchema`), default `false`, so existing JSON configs remain valid.
- Set ECS env `MIGRATE_NOTEBOOKS_ON_STARTUP` to `true` or `false` in `FaimsConductor` (matches `api/src/buildconfig.ts` parsing).
- Add the field to `infrastructure/aws-cdk/configs/sample.json`.

## How to Test

- `cd infrastructure/aws-cdk && npm install && npm test` (config unit tests).
- Deploy or `cdk synth` with a config that sets `"migrateNotebooksOnStartup": true` under `conductor` and confirm the task definition includes `MIGRATE_NOTEBOOKS_ON_STARTUP=true`.

## Additional Information

Upstream `main` was merged via fast-forward before this commit.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [ ] Relevant documentation such as READMEs, guides, and class comments are updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70fda927-837e-4633-8190-ba236ba28ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70fda927-837e-4633-8190-ba236ba28ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

