### PR TITLE
fix(cdk): wire migrateNotebooksOnStartup to API env

### DIFF
--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -109,7 +109,8 @@
       "scaleInCooldown": 300,
       "scaleOutCooldown": 60
     },
-    "localhostWhitelist": false
+    "localhostWhitelist": false,
+    "migrateNotebooksOnStartup": false
   },
   "authProviders": {
     "disableLocalLogin": false,

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -261,6 +261,9 @@ export class FaimsConductor extends Construct {
         AWS_SECRET_KEY_ARN: props.privateKeySecretArn,
         NEW_CONDUCTOR_URL: props.webUrl,
         PROVISION_SSO_USERS_POLICY: props.config.provisionSSOUsersPolicy,
+        MIGRATE_NOTEBOOKS_ON_STARTUP: props.config.migrateNotebooksOnStartup
+          ? 'true'
+          : 'false',
 
         // Bugsnag (optional)
         ...(props.bugsnagApiKey ? {BUGSNAG_API_KEY: props.bugsnagApiKey} : {}),

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -435,6 +435,9 @@ const ConductorConfigSchema = z.object({
   /** Allow localhost typical addresses in the redirects for conductor? NOT
    * recommended for production use cases (for security reasons). */
   localhostWhitelist: z.boolean().default(false),
+  /** When true, sets MIGRATE_NOTEBOOKS_ON_STARTUP so the API runs notebook DB
+   * migrations on startup. */
+  migrateNotebooksOnStartup: z.boolean().default(false),
 });
 
 const WebConfigSchema = z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The API honors `MIGRATE_NOTEBOOKS_ON_STARTUP` (`api/src/buildconfig.ts`), but CDK did not define it in stack JSON or set it on the Conductor ECS task. This wires `conductor.migrateNotebooksOnStartup` through to that env var (default `false`).

## Changes

- Extend `ConductorConfigSchema` with `migrateNotebooksOnStartup` (boolean, default `false`).
- Set `MIGRATE_NOTEBOOKS_ON_STARTUP` to `true`/`false` in `FaimsConductor` container env.
- Document in `infrastructure/aws-cdk/configs/sample.json`.

Signed-off-by included for DCO.

## How to test

`cd infrastructure/aws-cdk && pnpm install && pnpm test` (or `npm install && npm test`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70fda927-837e-4633-8190-ba236ba28ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70fda927-837e-4633-8190-ba236ba28ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

