### PR TITLE
chore: document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+FAIMS3 is an offline field data-collection platform. It is a pnpm + Turborepo
+monorepo (Node 22, `pnpm@10.7.0`). The relevant runnable services are:
+
+| Service | Package | Dev URL | Notes |
+| --- | --- | --- | --- |
+| Conductor API | `api` (`@faims3/api`) | http://localhost:8080 | Express server, talks to CouchDB |
+| Data-collection app | `app` (`@faims3/app`) | http://localhost:3000 | Vite PWA |
+| Control Centre / Designer | `web` (`@faims3/web`) | http://localhost:3001 | Vite web app (admin UI) |
+| CouchDB | docker | http://localhost:5984/_utils | Runs in Docker, not Node |
+
+Shared libraries: `library/data-model` (`@faims3/data-model`) and
+`library/forms` (`@faims3/forms`).
+
+### Startup (services are NOT started by the update script)
+
+The update script only runs `pnpm install`. To bring the stack up in a fresh
+session:
+
+1. Start the Docker daemon (CouchDB runs in Docker). Docker is preinstalled in
+   the snapshot but the daemon must be started each session, e.g. in a tmux
+   session: `sudo dockerd`. Wait a few seconds until `sudo docker info` works.
+2. Generate signing keys + CouchDB `local.ini` (idempotent; `keys/` and
+   `.env` files are gitignored so they may be missing on a fresh VM):
+   `pnpm run generate-local-keys`. Then create env files if missing:
+   `cp ./.env.dist ./.env; for d in api web app; do [ -f ./$d/.env ] || cp ./$d/.env.dist ./$d/.env; done`
+3. Start CouchDB only: `sudo docker compose up -d --build couchdb`, then wait
+   for `curl http://localhost:5984/_up` to return 200.
+4. Initialise the database (creates the `admin` user): `pnpm run migrate-with-keys`.
+5. Run all dev services with live reload: `pnpm run dev` (turbo runs api, app,
+   web and the data-model watcher in parallel). Run it in a long-lived tmux
+   session; it stays in the foreground.
+
+`./localdev.sh` / `./dev.sh` automate steps 1-5 but assume `nvm`; running the
+steps directly (as above) is more reliable in this VM. `./localdev.sh --all`
+runs every service inside Docker instead of natively — slower and not needed
+for code work.
+
+### Non-obvious gotchas
+
+- Shared libraries must be built before the API/migrate can resolve
+  `@faims3/data-model` / `@faims3/forms` (their package `main` points at build
+  output). `pnpm run dev` builds them automatically via the turbo `dev` ->
+  `build` dependency; if you run `pnpm run migrate-with-keys` on a fresh tree
+  first, run `pnpm build` (or `npx turbo build`) once beforehand.
+- Local admin credentials: username `admin`, password
+  `aSecretPasswordThatCantBeGuessed` (the `COUCHDB_PASSWORD` in `api/.env`).
+  The Control Centre (`:3001`) redirects to the Conductor login at
+  `:8080/login`; the green "Sign in" button is the local-login option.
+- Creating a Template or Project in the Control Centre requires the user to
+  belong to a Team first. Create a Team (Teams -> "+ Create Team") before
+  "+ Create Template", otherwise you get "You do not have permission to create
+  templates."
+- The database starts empty. To load sample data, follow the README
+  ("Loading sample notebooks and templates") which needs a bearer token, or run
+  `cd api && pnpm seed-test-dataset` against an empty DB.
+
+### Lint / test / build (standard commands, see `package.json`)
+
+- Lint everything: `npx turbo lint` (or `pnpm lint`). The `@faims3/forms`
+  circular-dependency notice is a pre-existing warning, not a failure.
+- Format: `pnpm format` (oxfmt) / `pnpm format:check`.
+- Build everything: `pnpm build` (`npx turbo build`).
+- Tests per package (no single repo-wide test script):
+  `pnpm --filter=@faims3/data-model test` (jest),
+  `pnpm --filter=@faims3/api test` (mocha; uses in-memory PouchDB, no CouchDB
+  needed), `pnpm --filter=@faims3/app test` (vitest).
+  Note `web` and `forms` use bare `vitest`, which watches in a TTY — pass
+  `--run` (e.g. `pnpm --filter=@faims3/web exec vitest --run`) for one-shot runs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Sets up and verifies the local development environment for the FAIMS3 monorepo in the Cursor Cloud VM, and records durable, non-obvious startup guidance for future cloud agents. No application code is changed — the only file added is `AGENTS.md`.

## Proposed Changes

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section: service map (Conductor API `:8080`, app `:3000`, Control Centre/Designer `:3001`, CouchDB `:5984`), startup steps, lint/test/build commands, and gotchas (Docker daemon must be started each session; shared libs must be built before migrate/API; local admin creds; a Team is required before creating a Template/Project).
- Configure the VM update script to `pnpm install` (minimal dependency refresh). Docker engine is installed into the VM snapshot; service startup, key generation, CouchDB, and migrations are documented in `AGENTS.md` rather than baked into the update script.

## How to Test

1. Start Docker (`sudo dockerd`), then `pnpm install` and `pnpm build`.
2. `pnpm run generate-local-keys`, copy `.env.dist` → `.env` files, `sudo docker compose up -d --build couchdb`, `pnpm run migrate-with-keys`.
3. `pnpm run dev` and confirm `:8080`, `:3000`, `:3001` respond.

Verified in this environment:
- Build: `npx turbo build` (6/6 packages)
- Lint: `npx turbo lint` (6/6)
- Tests: data-model jest (317), api mocha (344), app vitest (84)
- End-to-end: logged into the Control Centre as `admin`, created a Team, created the "Hello World Survey" Template, added a form/section/text field in the designer, and confirmed it persisted in the Templates list.

## Walkthrough

[faims3_control_centre_create_template.mp4](https://cursor.com/agents/bc-b762743b-865e-4473-b04f-68d4e0b3fcd6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffaims3_control_centre_create_template.mp4)

[Conductor local login](https://cursor.com/agents/bc-b762743b-865e-4473-b04f-68d4e0b3fcd6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffaims3_login.webp)
[Hello World Survey template in list](https://cursor.com/agents/bc-b762743b-865e-4473-b04f-68d4e0b3fcd6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffaims3_templates_list.webp)

## Additional Information

`.env` files, signing keys, and `api/couchdb/local.ini` are gitignored and generated locally, so they are not part of this PR.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [ ] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b762743b-865e-4473-b04f-68d4e0b3fcd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b762743b-865e-4473-b04f-68d4e0b3fcd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

