### PR TITLE
feat: user impersonation for system operations admins

### DIFF
--- a/api/src/api/users.ts
+++ b/api/src/api/users.ts
@@ -282,7 +282,9 @@ api.post(
     }
 
     if (target.user_id === user.user_id) {
-      throw new Exceptions.ForbiddenException('You cannot impersonate yourself.');
+      throw new Exceptions.ForbiddenException(
+        'You cannot impersonate yourself.'
+      );
     }
 
     if (isPeopleUserAccountDisabled(target)) {

--- a/api/src/api/users.ts
+++ b/api/src/api/users.ts
@@ -24,6 +24,7 @@ import {
   GetListAllUsersResponse,
   GetListAllUsersResponseSchema,
   isPeopleUserAccountDisabled,
+  PostImpersonateUserResponse,
   PostUpdateUserInputSchema,
   removeGlobalRole,
   Role,
@@ -35,6 +36,14 @@ import express, {Response} from 'express';
 import {z} from 'zod';
 import {processRequest} from 'zod-express-middleware';
 import {
+  generateUserToken,
+  upgradeCouchUserToExpressUser,
+} from '../auth/keySigning/create';
+import {
+  IMPERSONATION_SESSION_EXPIRY_MINUTES,
+  RUNNING_UNDER_TEST,
+} from '../buildconfig';
+import {
   filterPeopleUsersForList,
   getCouchUserFromEmailOrUserId,
   getUsers,
@@ -43,6 +52,7 @@ import {
 } from '../couchdb/users';
 import * as Exceptions from '../exceptions';
 import {isAllowedToMiddleware, requireAuthenticationAPI} from '../middleware';
+import {nowIso} from '../time';
 
 import patch from '../utils/patchExpressAsync';
 
@@ -233,6 +243,75 @@ api.post(
     target.disabled = false;
     await saveCouchUser(target);
     res.status(200).send();
+  }
+);
+
+/**
+ * Impersonate a user - trade a target user id for a token pair that
+ * authenticates as that user. Restricted to system operations administrators
+ * (Action.IMPERSONATE_USER).
+ *
+ * The returned tokens are a normal access + refresh token pair for the target
+ * user, so all downstream authorization treats the caller as the target. The
+ * access token is tagged with the acting admin's user id for auditing, and the
+ * refresh token is given a short lifetime so the impersonation session cannot
+ * linger.
+ */
+api.post(
+  '/:id/impersonate',
+  requireAuthenticationAPI,
+  isAllowedToMiddleware({
+    action: Action.IMPERSONATE_USER,
+    getResourceId(req) {
+      return req.params.id;
+    },
+  }),
+  processRequest({
+    params: z.object({id: z.string()}),
+  }),
+  async ({params: {id}, user}, res: Response<PostImpersonateUserResponse>) => {
+    if (!user) {
+      throw new Exceptions.UnauthorizedException();
+    }
+
+    const target = await getCouchUserFromEmailOrUserId(id);
+    if (!target) {
+      throw new Exceptions.ItemNotFoundException(
+        'Username cannot be found in user database.'
+      );
+    }
+
+    if (target.user_id === user.user_id) {
+      throw new Exceptions.ForbiddenException('You cannot impersonate yourself.');
+    }
+
+    if (isPeopleUserAccountDisabled(target)) {
+      throw new Exceptions.ForbiddenException(
+        'You cannot impersonate a disabled account.'
+      );
+    }
+
+    if (userHasGlobalRole({role: Role.GENERAL_ADMIN, user: target})) {
+      throw new Exceptions.ForbiddenException(
+        'You are not allowed to impersonate cluster admins.'
+      );
+    }
+
+    // Build a token as the target user, tagged with the acting admin id and
+    // given a short-lived refresh token.
+    const expressTarget = await upgradeCouchUserToExpressUser({dbUser: target});
+    const {token, refreshToken} = await generateUserToken(expressTarget, true, {
+      impersonatingUserId: user.user_id,
+      refreshExpiryMs: IMPERSONATION_SESSION_EXPIRY_MINUTES * 60 * 1000,
+    });
+
+    if (!RUNNING_UNDER_TEST) {
+      console.log(
+        `[Impersonation] ${user.user_id} started impersonating ${target.user_id} at ${nowIso()}`
+      );
+    }
+
+    res.json({accessToken: token, refreshToken: refreshToken!});
   }
 );
 

--- a/api/src/auth/keySigning/create.ts
+++ b/api/src/auth/keySigning/create.ts
@@ -135,9 +135,13 @@ export async function upgradeCouchUserToExpressUser({
 export async function generateJwtFromUser({
   user,
   signingKey,
+  impersonatingUserId,
 }: {
   user: Express.User;
   signingKey: SigningKey;
+  // When present, this token is an impersonation token issued by the given
+  // admin user id. Recorded in the payload for auditing.
+  impersonatingUserId?: string;
 }) {
   // The data model provides this encoding method - it takes the couch user
   // details and determines how to put that into the token
@@ -153,6 +157,7 @@ export async function generateJwtFromUser({
       name: user.name,
       server: CONDUCTOR_PUBLIC_URL,
       username: user.user_id,
+      ...(impersonatingUserId ? {impersonatingUserId} : {}),
     };
 
     // Then there are other parts we wish to include
@@ -182,19 +187,40 @@ export async function generateJwtFromUser({
  * @returns The generated token which is a payload containing the actual JWT +
  * refresh token + other information
  */
-export async function generateUserToken(user: Express.User, refresh = false) {
+export async function generateUserToken(
+  user: Express.User,
+  refresh = false,
+  options: {
+    // When present, tags the access token as an impersonation token issued by
+    // the given admin user id (for auditing).
+    impersonatingUserId?: string;
+    // When provided (and refresh === true), controls the lifetime of the
+    // generated refresh token. Used to keep impersonation sessions short.
+    refreshExpiryMs?: number;
+  } = {}
+) {
+  const {impersonatingUserId, refreshExpiryMs} = options;
   const signingKey = await KEY_SERVICE.getSigningKey();
 
   if (signingKey === null || signingKey === undefined) {
     throw new Error('No signing key is available, check configuration');
   } else {
-    const token = await generateJwtFromUser({user, signingKey});
+    const token = await generateJwtFromUser({
+      user,
+      signingKey,
+      impersonatingUserId,
+    });
 
     return {
       token: token,
       // Provide a refresh token if necessary
       refreshToken: refresh
-        ? (await createNewRefreshToken({userId: user._id!})).refresh.token
+        ? (
+            await createNewRefreshToken({
+              userId: user._id!,
+              ...(refreshExpiryMs !== undefined ? {refreshExpiryMs} : {}),
+            })
+          ).refresh.token
         : undefined,
       pubkey: signingKey.publicKeyString,
       pubalg: signingKey.alg,

--- a/api/src/auth/keySigning/read.ts
+++ b/api/src/auth/keySigning/read.ts
@@ -68,8 +68,15 @@ export const validateToken = async (
     // TODO consider if we want a more sophisticated permission merge, for
     // example in the case of blacklisting
 
+    // If this is an impersonation token, surface the acting admin's user id so
+    // it can be used for auditing/logging of downstream actions.
+    const impersonatingUserId =
+      typeof (payload as any).impersonatingUserId === 'string'
+        ? ((payload as any).impersonatingUserId as string)
+        : undefined;
+
     // overwrite user details with the token permissions!
-    return {...user, ...validatedToken};
+    return {...user, ...validatedToken, impersonatingUserId};
   } catch (error) {
     // expired token is ok, we just return undefined
     if (

--- a/api/src/buildconfig.ts
+++ b/api/src/buildconfig.ts
@@ -325,6 +325,30 @@ function refreshTokenExpiryMinutes(): number {
   }
 }
 
+// 60 minute default expiry for impersonation sessions. Impersonation sessions
+// are kept short so that an admin's "log in as" session cannot linger.
+const DEFAULT_IMPERSONATION_SESSION_EXPIRY_MINUTES = 60;
+
+/**
+ * @returns The lifetime (in minutes) of the refresh token issued for an
+ * impersonation session.
+ */
+function impersonationSessionExpiryMinutes(): number {
+  const value = process.env.IMPERSONATION_SESSION_EXPIRY_MINUTES;
+  if (value === '' || value === undefined) {
+    return DEFAULT_IMPERSONATION_SESSION_EXPIRY_MINUTES;
+  }
+  try {
+    return parseInt(value);
+  } catch (err) {
+    console.error(
+      'IMPERSONATION_SESSION_EXPIRY_MINUTES unparseable, defaulting to ' +
+        DEFAULT_IMPERSONATION_SESSION_EXPIRY_MINUTES
+    );
+    return DEFAULT_IMPERSONATION_SESSION_EXPIRY_MINUTES;
+  }
+}
+
 // 30 minute default expiry for email verification codes
 const DEFAULT_EMAIL_CODE_EXPIRY_MINUTES = 30;
 
@@ -459,6 +483,8 @@ export const ANDROID_APP_URL = android_url();
 export const IOS_APP_URL = ios_url();
 export const ACCESS_TOKEN_EXPIRY_MINUTES = accessTokenExpiryMinutes();
 export const REFRESH_TOKEN_EXPIRY_MINUTES = refreshTokenExpiryMinutes();
+export const IMPERSONATION_SESSION_EXPIRY_MINUTES =
+  impersonationSessionExpiryMinutes();
 export const DESIGNER_URL = designer_url();
 export const RATE_LIMITER_WINDOW_MS = rateLimiterWindowMs();
 export const RATE_LIMITER_PER_WINDOW = rateLimiterPerWindow();

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -41,6 +41,9 @@ declare global {
     interface User extends PeopleDBDocument {
       // The drilled resource roles which pre-compute the teams membership etc
       resourceRoles: ResourceRole[];
+      // Set when this session was created via impersonation; holds the user id
+      // of the admin who initiated the impersonation (for auditing).
+      impersonatingUserId?: string;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/api/test/impersonate.test.ts
+++ b/api/test/impersonate.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2021, 2022 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: impersonate.test.ts
+ * Description:
+ *   Tests for the user impersonation endpoint (POST /api/users/:id/impersonate)
+ */
+
+import PouchDB from 'pouchdb';
+import PouchDBFind from 'pouchdb-find';
+PouchDB.plugin(require('pouchdb-adapter-memory')); // enable memory adapter for testing
+PouchDB.plugin(PouchDBFind);
+
+import {
+  addGlobalRole,
+  PostImpersonateUserResponseSchema,
+  PostRefreshTokenInput,
+  PostRefreshTokenResponseSchema,
+  Role,
+} from '@faims3/data-model';
+import {expect} from 'chai';
+import request from 'supertest';
+import {
+  generateJwtFromUser,
+  upgradeCouchUserToExpressUser,
+} from '../src/auth/keySigning/create';
+import {validateToken} from '../src/auth/keySigning/read';
+import {KEY_SERVICE} from '../src/buildconfig';
+import {
+  createUser,
+  getCouchUserFromEmailOrUserId,
+  saveCouchUser,
+} from '../src/couchdb/users';
+import {app} from '../src/expressSetup';
+import {
+  adminToken,
+  adminUserName,
+  beforeApiTests,
+  localUserName,
+  localUserToken,
+} from './utils';
+
+// An operations admin (the intended audience) and a normal target user created
+// fresh for each test.
+const opsAdminUsername = 'opsadmin';
+const targetUsername = 'targetuser';
+let opsAdminToken = '';
+
+/**
+ * Creates a user with the given global roles and returns a signed JWT for them.
+ */
+const createUserWithRolesAndToken = async ({
+  username,
+  roles,
+}: {
+  username: string;
+  roles: Role[];
+}): Promise<string> => {
+  const signingKey = await KEY_SERVICE.getSigningKey();
+  const [dbUser, error] = await createUser({username, name: username});
+  expect(dbUser, `Failed to create user ${username}: ${error}`).to.not.be.null;
+  for (const role of roles) {
+    addGlobalRole({user: dbUser!, role});
+  }
+  await saveCouchUser(dbUser!);
+  const expressUser = await upgradeCouchUserToExpressUser({dbUser: dbUser!});
+  return await generateJwtFromUser({user: expressUser, signingKey});
+};
+
+describe('user impersonation', () => {
+  beforeEach(async () => {
+    await beforeApiTests();
+    // Create an operations admin and a plain target user for these tests.
+    opsAdminToken = await createUserWithRolesAndToken({
+      username: opsAdminUsername,
+      roles: [Role.OPERATIONS_ADMIN],
+    });
+    await createUserWithRolesAndToken({
+      username: targetUsername,
+      roles: [],
+    });
+  });
+
+  const impersonateUrl = (id: string) =>
+    `/api/users/${encodeURIComponent(id)}/impersonate`;
+
+  it('requires authentication', async () => {
+    await request(app).post(impersonateUrl(targetUsername)).expect(401);
+  });
+
+  it('is forbidden for non-admin users', async () => {
+    // localUser has no roles -> not authorised
+    await request(app)
+      .post(impersonateUrl(targetUsername))
+      .set('Authorization', `Bearer ${localUserToken}`)
+      .expect(401);
+  });
+
+  it('allows an operations admin to impersonate a normal user', async () => {
+    const body = await request(app)
+      .post(impersonateUrl(targetUsername))
+      .set('Authorization', `Bearer ${opsAdminToken}`)
+      .expect(200)
+      .then(res => PostImpersonateUserResponseSchema.parse(res.body));
+
+    expect(body.accessToken).to.be.a('string');
+    expect(body.refreshToken).to.be.a('string');
+
+    // The access token should authenticate as the TARGET user, and carry the
+    // acting admin's id for auditing.
+    const decoded = await validateToken(body.accessToken);
+    expect(decoded, 'access token did not validate').to.not.be.undefined;
+    expect(decoded!.user_id).to.equal(targetUsername);
+    expect(decoded!.impersonatingUserId).to.equal(opsAdminUsername);
+  });
+
+  it('allows a general (cluster) admin to impersonate (via inheritance)', async () => {
+    const body = await request(app)
+      .post(impersonateUrl(targetUsername))
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200)
+      .then(res => PostImpersonateUserResponseSchema.parse(res.body));
+
+    const decoded = await validateToken(body.accessToken);
+    expect(decoded!.user_id).to.equal(targetUsername);
+    expect(decoded!.impersonatingUserId).to.equal(adminUserName);
+  });
+
+  it('rejects impersonating yourself', async () => {
+    await request(app)
+      .post(impersonateUrl(opsAdminUsername))
+      .set('Authorization', `Bearer ${opsAdminToken}`)
+      .expect(403);
+  });
+
+  it('rejects impersonating a disabled account', async () => {
+    const target = (await getCouchUserFromEmailOrUserId(targetUsername))!;
+    target.disabled = true;
+    await saveCouchUser(target);
+
+    await request(app)
+      .post(impersonateUrl(targetUsername))
+      .set('Authorization', `Bearer ${opsAdminToken}`)
+      .expect(403);
+  });
+
+  it('rejects impersonating a cluster (GENERAL_ADMIN) account', async () => {
+    // adminUserName is a GENERAL_ADMIN
+    await request(app)
+      .post(impersonateUrl(adminUserName))
+      .set('Authorization', `Bearer ${opsAdminToken}`)
+      .expect(403);
+  });
+
+  it('returns 404 for an unknown user', async () => {
+    await request(app)
+      .post(impersonateUrl('no-such-user'))
+      .set('Authorization', `Bearer ${opsAdminToken}`)
+      .expect(404);
+  });
+
+  it('returns a usable refresh token for the impersonated session', async () => {
+    const body = await request(app)
+      .post(impersonateUrl(targetUsername))
+      .set('Authorization', `Bearer ${opsAdminToken}`)
+      .expect(200)
+      .then(res => PostImpersonateUserResponseSchema.parse(res.body));
+
+    // The refresh token should mint a fresh access token that still
+    // authenticates as the target user.
+    const refreshed = await request(app)
+      .post('/api/auth/refresh')
+      .send({refreshToken: body.refreshToken} satisfies PostRefreshTokenInput)
+      .expect(200)
+      .then(res => PostRefreshTokenResponseSchema.parse(res.body));
+
+    const decoded = await validateToken(refreshed.token);
+    expect(decoded!.user_id).to.equal(targetUsername);
+  });
+});

--- a/app/src/context/slices/authSlice.impersonation.test.ts
+++ b/app/src/context/slices/authSlice.impersonation.test.ts
@@ -1,0 +1,230 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+// Mock heavy/side-effectful deps so importing the slice is isolated.
+vi.mock('../../utils/apiOperations/users', () => ({
+  impersonateUser: vi.fn(),
+  listUsers: vi.fn(),
+}));
+// Mocked so the slice under test does not transitively import the real store
+// (client.tsx -> store.tsx) which sets up redux-persist/IndexedDB.
+vi.mock('../../utils/apiOperations/auth', () => ({
+  requestTokenRefresh: vi.fn(),
+}));
+vi.mock('./projectSlice', () => ({
+  // reducer default export (in case anything imports it)
+  default: (state = {servers: {}}) => state,
+  // dispatched + awaited by setServerConnection - no-op plain action
+  updateDatabaseCredentials: () => ({
+    type: 'projects/updateDatabaseCredentials/mock',
+  }),
+}));
+vi.mock('../../users', () => ({
+  parseToken: vi.fn(),
+}));
+
+import {TokenContents} from '@faims3/data-model';
+import {parseToken} from '../../users';
+import {impersonateUser} from '../../utils/apiOperations/users';
+import authReducer, {
+  assignServerConnection,
+  selectIsImpersonating,
+  setActiveUser,
+  startImpersonation,
+  stopImpersonation,
+} from './authSlice';
+
+const SERVER = 'server-1';
+const ADMIN = 'admin@example.com';
+const TARGET = 'fieldworker@example.com';
+
+/** Builds a minimal TokenContents for tests. */
+const fakeToken = (username: string): TokenContents =>
+  ({
+    username,
+    name: username,
+    server: 'http://localhost:8080',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    globalRoles: [],
+    resourceRoles: [],
+  }) as unknown as TokenContents;
+
+/** Builds a store whose state has the shape the thunks read. */
+const makeStore = () =>
+  configureStore({
+    reducer: {
+      auth: authReducer,
+      // minimal projects slice so getState().projects.servers exists
+      projects: (state = {servers: {}}) => state,
+    },
+  });
+
+describe('authSlice impersonation reducers', () => {
+  it('assignServerConnection sets the impersonatingUser marker', () => {
+    let state = authReducer(undefined, {type: '@@init'});
+    state = authReducer(
+      state,
+      assignServerConnection({
+        serverId: SERVER,
+        username: TARGET,
+        token: 't',
+        refreshToken: 'r',
+        parsedToken: fakeToken(TARGET),
+        impersonatingUser: ADMIN,
+      })
+    );
+    expect(state.servers[SERVER].users[TARGET].impersonatingUser).toBe(ADMIN);
+  });
+
+  it('preserves the impersonatingUser marker across a refresh (no marker in payload)', () => {
+    let state = authReducer(undefined, {type: '@@init'});
+    state = authReducer(
+      state,
+      assignServerConnection({
+        serverId: SERVER,
+        username: TARGET,
+        token: 't1',
+        refreshToken: 'r',
+        parsedToken: fakeToken(TARGET),
+        impersonatingUser: ADMIN,
+      })
+    );
+    // Simulate a refresh: same connection re-assigned with a new token but no
+    // impersonatingUser field.
+    state = authReducer(
+      state,
+      assignServerConnection({
+        serverId: SERVER,
+        username: TARGET,
+        token: 't2',
+        refreshToken: 'r',
+        parsedToken: fakeToken(TARGET),
+      })
+    );
+    expect(state.servers[SERVER].users[TARGET].token).toBe('t2');
+    expect(state.servers[SERVER].users[TARGET].impersonatingUser).toBe(ADMIN);
+  });
+
+  it('setActiveUser surfaces the marker and selectIsImpersonating reflects it', () => {
+    let state = authReducer(undefined, {type: '@@init'});
+    state = authReducer(
+      state,
+      assignServerConnection({
+        serverId: SERVER,
+        username: TARGET,
+        token: 't',
+        refreshToken: 'r',
+        parsedToken: fakeToken(TARGET),
+        impersonatingUser: ADMIN,
+      })
+    );
+    state = authReducer(
+      state,
+      setActiveUser({serverId: SERVER, username: TARGET})
+    );
+    expect(state.activeUser?.impersonatingUser).toBe(ADMIN);
+    expect(selectIsImpersonating({auth: state})).toBe(true);
+  });
+
+  it('selectIsImpersonating is false for a normal (non-impersonation) connection', () => {
+    let state = authReducer(undefined, {type: '@@init'});
+    state = authReducer(
+      state,
+      assignServerConnection({
+        serverId: SERVER,
+        username: ADMIN,
+        token: 't',
+        refreshToken: 'r',
+        parsedToken: fakeToken(ADMIN),
+      })
+    );
+    state = authReducer(
+      state,
+      setActiveUser({serverId: SERVER, username: ADMIN})
+    );
+    expect(selectIsImpersonating({auth: state})).toBe(false);
+  });
+});
+
+describe('authSlice impersonation thunks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const seedAdminActive = (store: ReturnType<typeof makeStore>) => {
+    store.dispatch(
+      assignServerConnection({
+        serverId: SERVER,
+        username: ADMIN,
+        token: 'admin-token',
+        refreshToken: 'admin-refresh',
+        parsedToken: fakeToken(ADMIN),
+      })
+    );
+    store.dispatch(setActiveUser({serverId: SERVER, username: ADMIN}));
+  };
+
+  it('startImpersonation adds the impersonated connection and makes it active', async () => {
+    const store = makeStore();
+    seedAdminActive(store);
+
+    (impersonateUser as any).mockResolvedValue({
+      accessToken: 'imp-access',
+      refreshToken: 'imp-refresh',
+    });
+    (parseToken as any).mockReturnValue(fakeToken(TARGET));
+
+    const result = await store
+      .dispatch(startImpersonation({serverId: SERVER, targetUserId: TARGET}))
+      .unwrap();
+
+    expect(result.status).toBe('success');
+    const state = store.getState().auth;
+    // impersonated connection stored + tagged, and is active
+    expect(state.servers[SERVER].users[TARGET].impersonatingUser).toBe(ADMIN);
+    expect(state.activeUser?.username).toBe(TARGET);
+    expect(state.activeUser?.impersonatingUser).toBe(ADMIN);
+    // admin connection retained
+    expect(state.servers[SERVER].users[ADMIN]).toBeDefined();
+    expect(impersonateUser).toHaveBeenCalledWith(SERVER, ADMIN, TARGET);
+  });
+
+  it('startImpersonation refuses when not signed in to the server', async () => {
+    const store = makeStore();
+    // no active user seeded
+    const result = await store
+      .dispatch(startImpersonation({serverId: SERVER, targetUserId: TARGET}))
+      .unwrap();
+    expect(result.status).toBe('error');
+    expect(impersonateUser).not.toHaveBeenCalled();
+  });
+
+  it('stopImpersonation restores the admin as active and removes the impersonated connection', async () => {
+    const store = makeStore();
+    seedAdminActive(store);
+
+    // Manually create an active impersonation session
+    store.dispatch(
+      assignServerConnection({
+        serverId: SERVER,
+        username: TARGET,
+        token: 'imp-access',
+        refreshToken: 'imp-refresh',
+        parsedToken: fakeToken(TARGET),
+        impersonatingUser: ADMIN,
+      })
+    );
+    store.dispatch(setActiveUser({serverId: SERVER, username: TARGET}));
+
+    // avoid real network in the best-effort logout
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ok: true}));
+
+    await store.dispatch(stopImpersonation());
+
+    const state = store.getState().auth;
+    expect(state.activeUser?.username).toBe(ADMIN);
+    expect(state.activeUser?.impersonatingUser).toBeUndefined();
+    // impersonated connection removed
+    expect(state.servers[SERVER]?.users[TARGET]).toBeUndefined();
+  });
+});

--- a/app/src/context/slices/authSlice.ts
+++ b/app/src/context/slices/authSlice.ts
@@ -565,9 +565,7 @@ export const startImpersonation = createAsyncThunk<
       );
 
       // Make it the active user.
-      appDispatch(
-        setActiveUser({serverId, username: parsedToken.username})
-      );
+      appDispatch(setActiveUser({serverId, username: parsedToken.username}));
 
       return {status: 'success', message: ''};
     } catch (error) {

--- a/app/src/context/slices/authSlice.ts
+++ b/app/src/context/slices/authSlice.ts
@@ -1,4 +1,4 @@
-import {TokenContents} from '@faims3/data-model';
+import {PutLogoutInput, TokenContents} from '@faims3/data-model';
 import {
   createAsyncThunk,
   createSelector,
@@ -8,6 +8,7 @@ import {
 import {TOKEN_REFRESH_WINDOW_MS} from '../../buildconfig';
 import {parseToken} from '../../users';
 import {requestTokenRefresh} from '../../utils/apiOperations/auth';
+import {impersonateUser} from '../../utils/apiOperations/users';
 import {AppDispatch, RootState} from '../store';
 import {updateDatabaseCredentials} from './projectSlice';
 import {addAlert} from './alertSlice';
@@ -18,6 +19,11 @@ export interface TokenInfo {
   refreshToken?: string;
   parsedToken: TokenContents;
   expiresAt: number;
+  // Present only for impersonation sessions: the username of the admin who
+  // initiated the impersonation (i.e. the connection to return to). Stored in
+  // state so it survives token refreshes (the JWT audit claim is dropped on
+  // refresh).
+  impersonatingUser?: string;
 }
 
 export interface ServerUserMap {
@@ -36,6 +42,8 @@ export interface ActiveUser {
   token: string;
   parsedToken: TokenContents;
   expiresAt: number;
+  // Present only for impersonation sessions - the admin username to return to.
+  impersonatingUser?: string;
 }
 
 export interface AuthState {
@@ -52,6 +60,10 @@ export interface SetServerConnectionInput {
   refreshToken?: string;
   parsedToken: TokenContents;
   promptRefresh?: boolean; // default false
+  // When set, marks this connection as an impersonation session initiated by
+  // the given admin username. Omitted on refresh - the existing marker is
+  // preserved by the reducer.
+  impersonatingUser?: string;
 }
 
 export interface ServerUserIdentity {
@@ -136,11 +148,18 @@ const authSlice = createSlice({
         state.servers[serverId] = {users: {}};
       }
 
+      // Preserve any existing impersonation marker across refreshes (refresh
+      // does not pass impersonatingUser), or set it when explicitly provided.
+      const impersonatingUser =
+        action.payload.impersonatingUser ??
+        state.servers[serverId].users[username]?.impersonatingUser;
+
       state.servers[serverId].users[username] = {
         token,
         refreshToken,
         parsedToken,
         expiresAt,
+        impersonatingUser,
       };
 
       // Update active user if this is the active user
@@ -151,6 +170,7 @@ const authSlice = createSlice({
       ) {
         state.activeUser.token = token;
         state.activeUser.parsedToken = parsedToken;
+        state.activeUser.impersonatingUser = impersonatingUser;
       }
 
       state.isAuthenticated = checkAuthenticationStatus(state);
@@ -172,6 +192,7 @@ const authSlice = createSlice({
         token: connection.token,
         parsedToken: connection.parsedToken,
         expiresAt: connection.expiresAt,
+        impersonatingUser: connection.impersonatingUser,
       };
 
       state.isAuthenticated = checkAuthenticationStatus(state);
@@ -222,6 +243,7 @@ const authSlice = createSlice({
               token: details.token,
               parsedToken: details.parsedToken,
               expiresAt: details.expiresAt,
+              impersonatingUser: details.impersonatingUser,
             };
             state.isAuthenticated = checkAuthenticationStatus(state);
           } else {
@@ -248,6 +270,9 @@ const authSlice = createSlice({
 export const selectActiveUser = (state: AuthStore) => state.auth.activeUser;
 export const selectIsAuthenticated = (state: AuthStore) =>
   state.auth.isAuthenticated;
+/** True when the active connection is an impersonation session. */
+export const selectIsImpersonating = (state: AuthStore) =>
+  !!state.auth.activeUser?.impersonatingUser;
 export const selectActiveToken = (state: AuthStore) => {
   const activeUser = state.auth.activeUser;
   if (!activeUser) return undefined;
@@ -484,6 +509,133 @@ export const refreshAllUsers = createAsyncThunk<void, void>(
         );
       }
     }
+  }
+);
+
+/**
+ * Begins impersonating a user on the active server. Calls the impersonation
+ * endpoint as the current (admin) active user, stores the returned token pair
+ * as an additional connection tagged with the admin's username, and makes it
+ * the active user. The admin's own connection is retained so it can be restored
+ * via stopImpersonation.
+ */
+export const startImpersonation = createAsyncThunk<
+  {status: 'success' | 'error'; message: string},
+  {serverId: string; targetUserId: string}
+>(
+  'auth/startImpersonation',
+  async ({serverId, targetUserId}, {dispatch, getState}) => {
+    const state = getState() as RootState;
+    const appDispatch = dispatch as AppDispatch;
+
+    const activeUser = state.auth.activeUser;
+    if (!activeUser || activeUser.serverId !== serverId) {
+      const message = 'You must be signed in to this server to impersonate.';
+      appDispatch(addAlert({message, severity: 'warning'}));
+      return {status: 'error', message};
+    }
+
+    if (activeUser.impersonatingUser) {
+      const message =
+        'Already impersonating a user. Return to your account first.';
+      appDispatch(addAlert({message, severity: 'warning'}));
+      return {status: 'error', message};
+    }
+
+    const adminUsername = activeUser.username;
+
+    try {
+      const {accessToken, refreshToken} = await impersonateUser(
+        serverId,
+        adminUsername,
+        targetUserId
+      );
+      const parsedToken = parseToken(accessToken);
+
+      // Store the impersonated user as a new connection, tagged with the admin.
+      await appDispatch(
+        setServerConnection({
+          serverId,
+          username: parsedToken.username,
+          token: accessToken,
+          refreshToken,
+          parsedToken,
+          impersonatingUser: adminUsername,
+        })
+      );
+
+      // Make it the active user.
+      appDispatch(
+        setActiveUser({serverId, username: parsedToken.username})
+      );
+
+      return {status: 'success', message: ''};
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to start impersonation.';
+      appDispatch(addAlert({message, severity: 'error'}));
+      return {status: 'error', message};
+    }
+  }
+);
+
+/**
+ * Ends the current impersonation session: restores the admin connection as the
+ * active user and removes the impersonated connection (best-effort invalidating
+ * its refresh token on the server).
+ */
+export const stopImpersonation = createAsyncThunk<void, void>(
+  'auth/stopImpersonation',
+  async (_, {dispatch, getState}) => {
+    const state = getState() as RootState;
+    const appDispatch = dispatch as AppDispatch;
+
+    const activeUser = state.auth.activeUser;
+    if (!activeUser?.impersonatingUser) {
+      // Not impersonating - nothing to do.
+      return;
+    }
+
+    const {serverId} = activeUser;
+    const impersonatedUsername = activeUser.username;
+    const adminUsername = activeUser.impersonatingUser;
+
+    // Restore the admin as the active user if their connection still exists.
+    const adminConnection = state.auth.servers[serverId]?.users[adminUsername];
+    if (adminConnection) {
+      appDispatch(setActiveUser({serverId, username: adminUsername}));
+    } else {
+      appDispatch(clearActiveConnection());
+    }
+
+    // Best-effort: invalidate the impersonated session's refresh token.
+    const impersonatedConnection =
+      state.auth.servers[serverId]?.users[impersonatedUsername];
+    const serverUrl = (getState() as RootState).projects.servers[serverId]
+      ?.serverUrl;
+    if (serverUrl && impersonatedConnection?.refreshToken) {
+      try {
+        await fetch(`${serverUrl}/auth/logout`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${impersonatedConnection.token}`,
+          },
+          body: JSON.stringify({
+            refreshToken: impersonatedConnection.refreshToken,
+          } satisfies PutLogoutInput),
+        });
+      } catch (error) {
+        console.warn('Failed to invalidate impersonation token:', error);
+      }
+    }
+
+    // Remove the impersonated connection.
+    appDispatch(
+      removeServerConnection({serverId, username: impersonatedUsername})
+    );
   }
 );
 

--- a/app/src/gui/components/authentication/appbarAuth.tsx
+++ b/app/src/gui/components/authentication/appbarAuth.tsx
@@ -55,7 +55,11 @@ import {addAlert} from '../../../context/slices/alertSlice';
 import {useAppDispatch, useAppSelector} from '../../../context/store';
 import {theme} from '../../themes';
 import {Server} from '../../../context/slices/projectSlice';
-import {Action, globalRolesGrantAction, PutLogoutInput} from '@faims3/data-model';
+import {
+  Action,
+  globalRolesGrantAction,
+  PutLogoutInput,
+} from '@faims3/data-model';
 import ImpersonateDialog from './impersonate-dialog';
 
 const SignInButtonComponent = () => {

--- a/app/src/gui/components/authentication/appbarAuth.tsx
+++ b/app/src/gui/components/authentication/appbarAuth.tsx
@@ -24,6 +24,7 @@ import {
   ExpandMore,
   Person,
   Settings,
+  SupervisorAccount,
 } from '@mui/icons-material';
 import LogoutIcon from '@mui/icons-material/Logout';
 import {
@@ -46,6 +47,7 @@ import {
   removeServerConnection,
   selectActiveUser,
   selectIsAuthenticated,
+  selectIsImpersonating,
   setActiveUser,
   TokenInfo,
 } from '../../../context/slices/authSlice';
@@ -53,7 +55,8 @@ import {addAlert} from '../../../context/slices/alertSlice';
 import {useAppDispatch, useAppSelector} from '../../../context/store';
 import {theme} from '../../themes';
 import {Server} from '../../../context/slices/projectSlice';
-import {PutLogoutInput} from '@faims3/data-model';
+import {Action, globalRolesGrantAction, PutLogoutInput} from '@faims3/data-model';
+import ImpersonateDialog from './impersonate-dialog';
 
 const SignInButtonComponent = () => {
   return (
@@ -88,12 +91,21 @@ const SignInButtonComponent = () => {
 const AuthenticatedDisplayComponent = () => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [switchMenuOpen, setSwitchMenuOpen] = React.useState(false);
+  const [impersonateOpen, setImpersonateOpen] = React.useState(false);
   const open = Boolean(anchorEl);
   const navigate = useNavigate();
 
   const authState = useAppSelector(state => state.auth);
   const {activeUser, servers: authServers} = authState;
+  const isImpersonating = useAppSelector(selectIsImpersonating);
   const dispatch = useAppDispatch();
+
+  // Only users whose global roles grant IMPERSONATE_USER may see the option,
+  // and never while already impersonating.
+  const canImpersonate =
+    !!activeUser &&
+    !isImpersonating &&
+    globalRolesGrantAction(activeUser.parsedToken, Action.IMPERSONATE_USER);
 
   const userInitial =
     activeUser?.parsedToken.username.charAt(0).toUpperCase() || '';
@@ -368,6 +380,21 @@ const AuthenticatedDisplayComponent = () => {
           </div>
         )}
 
+        {/* Impersonate user (admins only) */}
+        {canImpersonate && (
+          <MenuItem
+            onClick={() => {
+              setImpersonateOpen(true);
+              handleClose();
+            }}
+          >
+            <ListItemIcon>
+              <SupervisorAccount fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Impersonate user" />
+          </MenuItem>
+        )}
+
         {/* Manage Button */}
         <MenuItem component={NavLink} to={ROUTES.SIGN_IN} onClick={handleClose}>
           <ListItemIcon>
@@ -394,6 +421,11 @@ const AuthenticatedDisplayComponent = () => {
           </MenuItem>
         )}
       </Menu>
+
+      <ImpersonateDialog
+        open={impersonateOpen}
+        onClose={() => setImpersonateOpen(false)}
+      />
     </>
   );
 };

--- a/app/src/gui/components/authentication/impersonate-dialog.tsx
+++ b/app/src/gui/components/authentication/impersonate-dialog.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2021, 2022 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: impersonate-dialog.tsx
+ * Description:
+ *   Dialog allowing an authorised admin to pick a user to impersonate.
+ */
+
+import {GetListAllUsersItem, Role} from '@faims3/data-model';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItemButton,
+  ListItemText,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {useQuery} from '@tanstack/react-query';
+import React, {useMemo, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import * as ROUTES from '../../../constants/routes';
+import {
+  selectActiveUser,
+  startImpersonation,
+} from '../../../context/slices/authSlice';
+import {useAppDispatch, useAppSelector} from '../../../context/store';
+import {listUsers} from '../../../utils/apiOperations/users';
+
+/**
+ * A dialog which lists users on the active server and lets the admin start
+ * impersonating one of them. The current user and cluster admins are excluded.
+ */
+export default function ImpersonateDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const activeUser = useAppSelector(selectActiveUser);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const [search, setSearch] = useState('');
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const serverId = activeUser?.serverId;
+  const adminUsername = activeUser?.username;
+
+  const {data, isLoading, isError, error} = useQuery({
+    queryKey: ['impersonation-users', serverId, adminUsername],
+    queryFn: async () => listUsers(serverId!, adminUsername!),
+    enabled: open && !!serverId && !!adminUsername,
+    networkMode: 'always',
+  });
+
+  const candidates = useMemo(() => {
+    const users = (data ?? []) as GetListAllUsersItem[];
+    const term = search.trim().toLowerCase();
+    return users
+      .filter(u => {
+        // cannot impersonate yourself
+        if (u._id === adminUsername) return false;
+        // cannot impersonate cluster admins
+        if ((u.globalRoles ?? []).includes(Role.GENERAL_ADMIN)) return false;
+        // cannot impersonate disabled accounts
+        if (u.disabled) return false;
+        return true;
+      })
+      .filter(u => {
+        if (!term) return true;
+        const email = u.emails[0]?.email ?? '';
+        return (
+          (u.name ?? '').toLowerCase().includes(term) ||
+          u._id.toLowerCase().includes(term) ||
+          email.toLowerCase().includes(term)
+        );
+      });
+  }, [data, search, adminUsername]);
+
+  const handleImpersonate = async (targetUserId: string) => {
+    if (!serverId) return;
+    setPendingId(targetUserId);
+    const {status} = await dispatch(
+      startImpersonation({serverId, targetUserId})
+    ).unwrap();
+    setPendingId(null);
+    if (status === 'success') {
+      onClose();
+      navigate(ROUTES.INDEX);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Impersonate a user</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" sx={{mb: 2}}>
+          Choose a user to sign in as. You will see what they see, and actions
+          you take will be performed as this user. Use “Return to your account”
+          in the banner to end impersonation.
+        </Typography>
+
+        <TextField
+          fullWidth
+          size="small"
+          label="Search by name, email or username"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          sx={{mb: 2}}
+        />
+
+        {isLoading && (
+          <Box sx={{display: 'flex', justifyContent: 'center', p: 3}}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {isError && (
+          <Alert severity="error">
+            Could not load users:{' '}
+            {error instanceof Error ? error.message : 'Unknown error'}
+          </Alert>
+        )}
+
+        {!isLoading && !isError && candidates.length === 0 && (
+          <Alert severity="info">No users available to impersonate.</Alert>
+        )}
+
+        {!isLoading && !isError && candidates.length > 0 && (
+          <List dense sx={{maxHeight: 360, overflow: 'auto'}}>
+            {candidates.map(user => (
+              <ListItemButton
+                key={user._id}
+                disabled={pendingId !== null}
+                onClick={() => handleImpersonate(user._id)}
+              >
+                <ListItemText
+                  primary={user.name || user._id}
+                  secondary={user.emails[0]?.email ?? user._id}
+                />
+                {pendingId === user._id && <CircularProgress size={18} />}
+              </ListItemButton>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/gui/components/authentication/impersonation-banner.tsx
+++ b/app/src/gui/components/authentication/impersonation-banner.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021, 2022 Macquarie University
+ *
+ * Licensed under the Apache License Version 2.0 (the, "License");
+ * you may not use, this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See, the License, for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Filename: impersonation-banner.tsx
+ * Description:
+ *   App-wide banner shown while an admin is impersonating another user.
+ */
+
+import {Button} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import {useNavigate} from 'react-router-dom';
+import * as ROUTES from '../../../constants/routes';
+import {
+  selectActiveUser,
+  selectIsImpersonating,
+  stopImpersonation,
+} from '../../../context/slices/authSlice';
+import {useAppDispatch, useAppSelector} from '../../../context/store';
+
+/**
+ * Renders a prominent banner while the active session is an impersonation
+ * session, with a button to return to the admin's own account.
+ */
+export default function ImpersonationBanner() {
+  const isImpersonating = useAppSelector(selectIsImpersonating);
+  const activeUser = useAppSelector(selectActiveUser);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  if (!isImpersonating || !activeUser) {
+    return null;
+  }
+
+  const impersonatedName =
+    activeUser.parsedToken.name || activeUser.parsedToken.username;
+
+  const handleReturn = async () => {
+    await dispatch(stopImpersonation());
+    navigate(ROUTES.INDEX);
+  };
+
+  return (
+    <Alert
+      severity="warning"
+      variant="filled"
+      square
+      sx={{borderRadius: 0, alignItems: 'center'}}
+      action={
+        <Button color="inherit" size="small" onClick={handleReturn}>
+          Return to your account
+        </Button>
+      }
+    >
+      You are impersonating <strong>{impersonatedName}</strong> (as{' '}
+      {activeUser.impersonatingUser}). Actions are performed as this user.
+    </Alert>
+  );
+}

--- a/app/src/gui/layout/index.tsx
+++ b/app/src/gui/layout/index.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@mui/material/styles';
 import React from 'react';
 import {ErrorBoundary, ErrorPage} from '../../logging';
 import {PossibleToken} from '../../types/misc';
+import ImpersonationBanner from '../components/authentication/impersonation-banner';
 import Footer from '../components/footer';
 import MainAppBar from './appBar';
 
@@ -20,6 +21,7 @@ const MainLayout = (props: MainLayoutProps) => {
   return (
     <React.Fragment>
       <MainAppBar />
+      <ImpersonationBanner />
       <Box
         component="main"
         sx={{

--- a/app/src/utils/apiOperations/users.tsx
+++ b/app/src/utils/apiOperations/users.tsx
@@ -1,0 +1,42 @@
+import {
+  GetListAllUsersResponse,
+  PostImpersonateUserResponse,
+} from '@faims3/data-model';
+import FetchManager from './client';
+
+/**
+ * Lists all users on the given server (requires the VIEW_USER_LIST action).
+ * @param serverId The server to query
+ * @param username The username to authenticate as
+ */
+export const listUsers = async (
+  serverId: string,
+  username: string
+): Promise<GetListAllUsersResponse> => {
+  return await FetchManager.get<GetListAllUsersResponse>(
+    serverId,
+    username,
+    '/api/users'
+  );
+};
+
+/**
+ * Requests an impersonation token pair for the target user (requires the
+ * IMPERSONATE_USER action). The returned tokens authenticate as the target
+ * user.
+ * @param serverId The server to authenticate against
+ * @param username The username (admin) to authenticate as
+ * @param targetUserId The id of the user to impersonate
+ */
+export const impersonateUser = async (
+  serverId: string,
+  username: string,
+  targetUserId: string
+): Promise<PostImpersonateUserResponse> => {
+  return await FetchManager.post<PostImpersonateUserResponse>(
+    serverId,
+    username,
+    `/api/users/${encodeURIComponent(targetUserId)}/impersonate`,
+    {}
+  );
+};

--- a/library/data-model/src/api.ts
+++ b/library/data-model/src/api.ts
@@ -238,6 +238,17 @@ export type PostExchangeTokenResponse = z.infer<
   typeof PostExchangeTokenResponseSchema
 >;
 
+// Impersonation - an admin trades a target user id for a token pair that
+// authenticates as that user. No request body (target id is a path param).
+export const PostImpersonateUserResponseSchema = z.object({
+  // token pair for the impersonated user
+  refreshToken: z.string(),
+  accessToken: z.string(),
+});
+export type PostImpersonateUserResponse = z.infer<
+  typeof PostImpersonateUserResponseSchema
+>;
+
 // ==================
 // NOTEBOOKS CRUD
 // ==================

--- a/library/data-model/src/permission/model.ts
+++ b/library/data-model/src/permission/model.ts
@@ -205,6 +205,8 @@ export enum Action {
   DISABLE_USER_ACCOUNT = 'DISABLE_USER_ACCOUNT',
   // Re-enable a previously disabled user account
   ENABLE_USER_ACCOUNT = 'ENABLE_USER_ACCOUNT',
+  // Impersonate a user (obtain a session that authenticates as them)
+  IMPERSONATE_USER = 'IMPERSONATE_USER',
 
   // ============================================================
   // LONG LIVED TOKEN ACTIONS
@@ -798,6 +800,13 @@ export const actionDetails: Record<Action, ActionDetails> = {
     resourceSpecific: true,
     resource: Resource.USER,
   },
+  [Action.IMPERSONATE_USER]: {
+    name: 'Impersonate User',
+    description:
+      'Start a session that authenticates as another user (for support/debugging). Restricted to system operations administrators.',
+    resourceSpecific: true,
+    resource: Resource.USER,
+  },
 
   // ============================================================
   // GLOBAL ACTIONS
@@ -1215,6 +1224,7 @@ export const roleActions: Record<
       Action.DELETE_USER,
       Action.DISABLE_USER_ACCOUNT,
       Action.ENABLE_USER_ACCOUNT,
+      Action.IMPERSONATE_USER,
 
       // Irreversible survey destruction (also on PROJECT_ADMIN for owned surveys)
       Action.DELETE_PROJECT,

--- a/library/data-model/src/permission/types.ts
+++ b/library/data-model/src/permission/types.ts
@@ -30,6 +30,9 @@ export const tokenPayloadSchema = z
     server: z.string(),
     // username
     username: z.string(),
+    // Present only for impersonation sessions: the user id of the admin who
+    // initiated the impersonation. Used for auditing.
+    impersonatingUserId: z.string().optional(),
   })
   .merge(tokenPermissionsSchema);
 export type TokenPayload = z.infer<typeof tokenPayloadSchema>;
@@ -43,6 +46,9 @@ export interface TokenContents extends DecodedTokenPermissions {
   server: string;
   // This is required now - all tokens must have an expiry
   exp: number;
+  // Present only for impersonation sessions: the user id of the admin who
+  // initiated the impersonation. Used for auditing.
+  impersonatingUserId?: string;
 }
 
 // =======================================

--- a/library/data-model/tests/permissionfunctions.test.ts
+++ b/library/data-model/tests/permissionfunctions.test.ts
@@ -11,7 +11,7 @@ import {
   drillRoles,
   roleGrantsAction,
 } from '../src/permission/helpers';
-import {Action, Resource, Role} from '../src/permission/model';
+import {Action, actionDetails, Resource, Role} from '../src/permission/model';
 import {
   DecodedTokenPermissions,
   TokenPermissions,
@@ -1068,5 +1068,50 @@ describe('Virtual Resource Roles', () => {
       // No virtual roles should be generated
       expect(virtualRoles.length).toBe(0);
     });
+  });
+});
+
+describe('IMPERSONATE_USER permission', () => {
+  it('is granted to OPERATIONS_ADMIN', () => {
+    expect(
+      roleGrantsAction({
+        roles: [Role.OPERATIONS_ADMIN],
+        action: Action.IMPERSONATE_USER,
+      })
+    ).toBe(true);
+  });
+
+  it('is granted to GENERAL_ADMIN (via inheritance)', () => {
+    expect(
+      roleGrantsAction({
+        roles: [Role.GENERAL_ADMIN],
+        action: Action.IMPERSONATE_USER,
+      })
+    ).toBe(true);
+  });
+
+  it('is NOT granted to GENERAL_USER', () => {
+    expect(
+      roleGrantsAction({
+        roles: [Role.GENERAL_USER],
+        action: Action.IMPERSONATE_USER,
+      })
+    ).toBe(false);
+  });
+
+  it('is NOT granted to GENERAL_CREATOR', () => {
+    expect(
+      roleGrantsAction({
+        roles: [Role.GENERAL_CREATOR],
+        action: Action.IMPERSONATE_USER,
+      })
+    ).toBe(false);
+  });
+
+  it('is a resource-specific USER action', () => {
+    const details = actionDetails[Action.IMPERSONATE_USER];
+    expect(details).toBeDefined();
+    expect(details.resource).toBe(Resource.USER);
+    expect(details.resourceSpecific).toBe(true);
   });
 });

--- a/web/src/components/alerts/impersonation-banner.tsx
+++ b/web/src/components/alerts/impersonation-banner.tsx
@@ -7,7 +7,8 @@ import {VenetianMask} from 'lucide-react';
  * session. Provides a clear way to return to the admin's own account.
  */
 export function ImpersonationBanner() {
-  const {isImpersonating, user, impersonatorName, stopImpersonation} = useAuth();
+  const {isImpersonating, user, impersonatorName, stopImpersonation} =
+    useAuth();
 
   if (!isImpersonating) {
     return null;

--- a/web/src/components/alerts/impersonation-banner.tsx
+++ b/web/src/components/alerts/impersonation-banner.tsx
@@ -1,0 +1,38 @@
+import {useAuth} from '@/context/auth-provider';
+import {Button} from '@/components/ui/button';
+import {VenetianMask} from 'lucide-react';
+
+/**
+ * Persistent banner shown while the current session is an impersonation
+ * session. Provides a clear way to return to the admin's own account.
+ */
+export function ImpersonationBanner() {
+  const {isImpersonating, user, impersonatorName, stopImpersonation} = useAuth();
+
+  if (!isImpersonating) {
+    return null;
+  }
+
+  const impersonatedName = user?.user.name ?? user?.user.email ?? 'this user';
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border-2 border-amber-500 bg-amber-100 px-4 py-2 text-sm text-black">
+      <div className="flex items-center gap-2">
+        <VenetianMask className="h-4 w-4 shrink-0" />
+        <span>
+          You are impersonating <strong>{impersonatedName}</strong>
+          {impersonatorName ? ` (as ${impersonatorName})` : ''}. Actions are
+          performed as this user.
+        </span>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        className="border-amber-600 bg-white text-black hover:bg-amber-50"
+        onClick={() => stopImpersonation()}
+      >
+        Return to your account
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/dialogs/impersonate-user.tsx
+++ b/web/src/components/dialogs/impersonate-user.tsx
@@ -46,8 +46,7 @@ export function ImpersonateUserDialog({
     return null;
   }
 
-  const displayName =
-    rowUser.name || rowUser.emails[0]?.email || rowUser._id;
+  const displayName = rowUser.name || rowUser.emails[0]?.email || rowUser._id;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/web/src/components/dialogs/impersonate-user.tsx
+++ b/web/src/components/dialogs/impersonate-user.tsx
@@ -1,0 +1,119 @@
+import {WEB_URL} from '@/constants';
+import {useAuth} from '@/context/auth-provider';
+import {useIsAuthorisedTo} from '@/hooks/auth-hooks';
+import {useImpersonateUser} from '@/hooks/user-hooks';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {cn} from '@/lib/utils';
+import {Action, type GetListAllUsersItem, Role} from '@faims3/data-model';
+import {VenetianMask} from 'lucide-react';
+import {useState} from 'react';
+import {toast} from 'sonner';
+import {Button} from '../ui/button';
+
+/**
+ * Opens a confirmation to impersonate a user. On confirm, the current (admin)
+ * session is stashed and swapped for a session authenticating as the target
+ * user; the app reloads so all data is fetched as the impersonated user.
+ *
+ * Only rendered for admins authorised to impersonate, and never for the current
+ * user or for cluster (GENERAL_ADMIN) accounts.
+ */
+export function ImpersonateUserDialog({
+  rowUser,
+}: {
+  rowUser: GetListAllUsersItem;
+}) {
+  const [open, setOpen] = useState(false);
+  const {user} = useAuth();
+  const impersonate = useImpersonateUser();
+  const canImpersonate = useIsAuthorisedTo({
+    action: Action.IMPERSONATE_USER,
+    resourceId: rowUser._id,
+  });
+
+  const blocked =
+    rowUser._id === user?.user.id ||
+    (rowUser.globalRoles ?? []).includes(Role.GENERAL_ADMIN);
+
+  if (!canImpersonate || blocked) {
+    return null;
+  }
+
+  const displayName =
+    rowUser.name || rowUser.emails[0]?.email || rowUser._id;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild className="w-fit">
+        <Button variant="outline" title="Impersonate user">
+          <VenetianMask className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="text-black">
+        <DialogHeader>
+          <DialogTitle className="text-black">
+            Impersonate {displayName}
+          </DialogTitle>
+          <DialogDescription asChild className="text-black">
+            <div
+              className={cn(
+                'rounded-md border-2 border-amber-500 bg-amber-100 p-4 text-sm',
+                'text-black'
+              )}
+            >
+              <p className="font-medium text-black">Heads up:</p>
+              <ul className="mt-2 list-disc space-y-2 pl-5 text-black">
+                <li>
+                  You will be signed in as this user and see exactly what they
+                  see.
+                </li>
+                <li>
+                  Any actions you take will be performed and attributed as this
+                  user.
+                </li>
+                <li>
+                  Use &ldquo;Return to your account&rdquo; in the banner to end
+                  impersonation. The session also ends automatically after a
+                  short time.
+                </li>
+              </ul>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <Button
+          className="w-full"
+          disabled={impersonate.isPending}
+          onClick={() =>
+            impersonate.mutate(
+              {targetUserId: rowUser._id},
+              {
+                onSuccess: () => {
+                  setOpen(false);
+                  // Reload as the impersonated user for a clean session.
+                  window.location.href = WEB_URL;
+                },
+                onError: e => {
+                  console.error(e);
+                  toast.error(
+                    e instanceof Error
+                      ? e.message
+                      : 'Failed to impersonate user'
+                  );
+                },
+              }
+            )
+          }
+        >
+          {impersonate.isPending ? 'Starting…' : `Impersonate ${displayName}`}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/tables/users.tsx
+++ b/web/src/components/tables/users.tsx
@@ -11,6 +11,7 @@ import {KeyRound} from 'lucide-react';
 import {toast} from 'sonner';
 import {DataTableColumnHeader} from '../data-table/column-header';
 import {DisableUserDialog} from '../dialogs/disable-user';
+import {ImpersonateUserDialog} from '../dialogs/impersonate-user';
 import {AddRolePopover} from '../popovers/add-role-popover';
 import {Button} from '../ui/button';
 import {RoleCard} from '../ui/role-card';
@@ -154,6 +155,17 @@ export const useUsersColumns = ({
       },
       header: () => (
         <div className="flex justify-center items-center">Reset Password</div>
+      ),
+    },
+    {
+      id: 'impersonate',
+      cell: ({row: {original}}) => (
+        <div className="flex justify-center items-center -my-2">
+          <ImpersonateUserDialog rowUser={original} />
+        </div>
+      ),
+      header: () => (
+        <div className="flex justify-center items-center">Impersonate</div>
       ),
     },
     {

--- a/web/src/context/auth-provider.tsx
+++ b/web/src/context/auth-provider.tsx
@@ -229,7 +229,10 @@ export function AuthProvider({children}: {children: React.ReactNode}) {
 
     const admin = user;
     if (!admin) {
-      return {status: 'error', message: 'No active session to impersonate from'};
+      return {
+        status: 'error',
+        message: 'No active session to impersonate from',
+      };
     }
 
     // Stash the admin session first so it can be restored.

--- a/web/src/context/auth-provider.tsx
+++ b/web/src/context/auth-provider.tsx
@@ -35,11 +35,28 @@ export interface AuthContext {
   logout: () => void;
   user: User | null;
   refreshToken: () => Promise<{status: string; message: string}>;
+  /** True when the current session is an impersonation session. */
+  isImpersonating: boolean;
+  /** Display name (or email/id) of the admin who initiated impersonation. */
+  impersonatorName: string | null;
+  /**
+   * Begin impersonating a user given an impersonation token pair. Stashes the
+   * current (admin) session so it can be restored via {@link stopImpersonation}.
+   */
+  startImpersonation: (
+    token: string,
+    refreshToken: string
+  ) => Promise<{status: 'success' | 'error'; message: string}>;
+  /** End impersonation and restore the stashed admin session. */
+  stopImpersonation: () => void;
 }
 
 const AuthContext = createContext<AuthContext | null>(null);
 
 const key = 'user';
+// Separate storage slot holding the admin session while impersonating, so it
+// can be restored when impersonation ends.
+const impersonatorKey = 'impersonator';
 
 /**
  * Decodes a JWT token string into TokenContents.
@@ -87,6 +104,24 @@ export function getStoredUser(): User | null {
 }
 
 /**
+ * Stores or removes the stashed impersonator (admin) session in localStorage.
+ */
+function setStoredImpersonator(user: User | null) {
+  if (user) {
+    localStorage.setItem(impersonatorKey, JSON.stringify(user));
+  } else {
+    localStorage.removeItem(impersonatorKey);
+  }
+}
+
+/**
+ * Get the stashed impersonator (admin) session, if any.
+ */
+export function getStoredImpersonator(): User | null {
+  return parseUserJSON(localStorage.getItem(impersonatorKey));
+}
+
+/**
  * Parse the stored user from localStorage.
  *
  * @returns the User object if we have a valid user or null if not
@@ -124,11 +159,19 @@ export function AuthProvider({children}: {children: React.ReactNode}) {
     return getStoredUser();
   });
 
+  // The stashed admin session while impersonating (null when not impersonating).
+  const [impersonator, setImpersonatorState] = useState<User | null>(() => {
+    return getStoredImpersonator();
+  });
+
   const isExpired = () => {
     return isUserExpired(user);
   };
 
   const isAuthenticated = !!user && !isExpired();
+  const isImpersonating = !!impersonator;
+  const impersonatorName =
+    impersonator?.user.name ?? impersonator?.user.email ?? null;
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -160,6 +203,69 @@ export function AuthProvider({children}: {children: React.ReactNode}) {
       setStoredUser(null);
       setUser(null);
     }
+    // Clear any impersonation stash on logout.
+    setStoredImpersonator(null);
+    setImpersonatorState(null);
+    window.location.href = WEB_URL;
+  };
+
+  /**
+   * Begin impersonating a user. Stashes the current (admin) session under a
+   * separate key, then swaps the active session to the impersonated user using
+   * the provided token pair. On failure, the stash is rolled back.
+   */
+  const startImpersonation = async (
+    token: string,
+    refresh: string
+  ): Promise<{status: 'success' | 'error'; message: string}> => {
+    // Do not allow nested impersonation - end the current one first.
+    if (impersonator) {
+      return {
+        status: 'error',
+        message:
+          'Already impersonating a user. Return to your account before impersonating another.',
+      };
+    }
+
+    const admin = user;
+    if (!admin) {
+      return {status: 'error', message: 'No active session to impersonate from'};
+    }
+
+    // Stash the admin session first so it can be restored.
+    setStoredImpersonator(admin);
+    setImpersonatorState(admin);
+
+    // Swap the active session to the impersonated user.
+    const {status, message} = await getUserDetails(token, refresh);
+
+    if (status !== 'success') {
+      // Roll back the stash and restore the admin session.
+      setStoredImpersonator(null);
+      setImpersonatorState(null);
+      setStoredUser(admin);
+      setUser(admin);
+      return {status: 'error', message};
+    }
+
+    return {status: 'success', message: ''};
+  };
+
+  /**
+   * End impersonation and restore the stashed admin session. Reloads the app so
+   * that all queries refetch under the restored session.
+   */
+  const stopImpersonation = () => {
+    const admin = impersonator ?? getStoredImpersonator();
+    setStoredImpersonator(null);
+    setImpersonatorState(null);
+
+    if (admin) {
+      setStoredUser(admin);
+      setUser(admin);
+    }
+
+    // Fresh reload so all cached queries refetch under the restored session.
     window.location.href = WEB_URL;
   };
 
@@ -215,6 +321,16 @@ export function AuthProvider({children}: {children: React.ReactNode}) {
     );
 
     if (!response.ok) {
+      // If we were impersonating, an expired/failed impersonation session
+      // should return the admin to their own account rather than logging out.
+      if (getStoredImpersonator()) {
+        stopImpersonation();
+        return {
+          status: 'error',
+          message: 'Impersonation session ended; returned to your account.',
+        };
+      }
+
       setStoredUser(null);
       setUser(null);
 
@@ -253,6 +369,10 @@ export function AuthProvider({children}: {children: React.ReactNode}) {
         logout,
         refreshToken,
         isExpired,
+        isImpersonating,
+        impersonatorName,
+        startImpersonation,
+        stopImpersonation,
       }}
     >
       {children}

--- a/web/src/hooks/user-hooks.ts
+++ b/web/src/hooks/user-hooks.ts
@@ -1,4 +1,5 @@
 import {useAuth, type User} from '@/context/auth-provider';
+import {PostImpersonateUserResponseSchema} from '@faims3/data-model';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 function errorMessageFromUserJsonBody(
@@ -68,6 +69,61 @@ export const postEnableUserAccount = async ({
   const json: unknown = await response.json().catch(() => undefined);
   throw new Error(errorMessageFromUserJsonBody(json, response.statusText));
 };
+
+/**
+ * POST /api/users/:targetUserId/impersonate — obtain an impersonation token
+ * pair authenticating as the target user.
+ */
+export const postImpersonateUser = async ({
+  user,
+  targetUserId,
+}: {
+  user: User;
+  targetUserId: string;
+}) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_API_URL}/api/users/${encodeURIComponent(targetUserId)}/impersonate`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+      },
+    }
+  );
+  if (!response.ok) {
+    const json: unknown = await response.json().catch(() => undefined);
+    throw new Error(errorMessageFromUserJsonBody(json, response.statusText));
+  }
+  return PostImpersonateUserResponseSchema.parse(await response.json());
+};
+
+/**
+ * Mutation which starts impersonating the given user: fetches the impersonation
+ * token pair and swaps the active session (stashing the admin session so it can
+ * be restored).
+ */
+export function useImpersonateUser() {
+  const {user, startImpersonation} = useAuth();
+
+  return useMutation({
+    mutationFn: async ({targetUserId}: {targetUserId: string}) => {
+      if (!user) {
+        throw new Error('Not authenticated');
+      }
+      const {accessToken, refreshToken} = await postImpersonateUser({
+        user,
+        targetUserId,
+      });
+      const {status, message} = await startImpersonation(
+        accessToken,
+        refreshToken
+      );
+      if (status !== 'success') {
+        throw new Error(message || 'Failed to start impersonation');
+      }
+    },
+  });
+}
 
 export function useDisableUserAccount() {
   const queryClient = useQueryClient();

--- a/web/src/routes/_protected.tsx
+++ b/web/src/routes/_protected.tsx
@@ -1,3 +1,4 @@
+import {ImpersonationBanner} from '@/components/alerts/impersonation-banner';
 import {VerificationAlertComponent} from '@/components/alerts/verification-alert';
 import Breadcrumbs from '@/components/breadcrumbs';
 import {LogoIcon} from '@/components/logo';
@@ -209,6 +210,7 @@ function RouteComponent() {
           </header>
 
           <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+            <ImpersonationBanner />
             {verification.showNeedsVerification && (
               <VerificationAlertComponent
                 email={verification.email ?? 'Unknown'}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a **user impersonation** ("log in as") capability so a trusted global
administrator can obtain a session that authenticates as another user — for
support and reproducing what a user sees. Gated by a new permission-model action
and available only to **global system operations administrators**. Implemented in
**both** the Control Centre (`web`) and the data-collection app (`app`).

The design reuses the existing JWT machinery: `validateToken` rebuilds identity
from the token's `sub` claim + encoded roles, so a short-lived token whose `sub`
is the target makes the whole API treat the caller as that user — **no downstream
authorization logic was changed**.

## Proposed Changes

**Permission model (`@faims3/data-model`)**
- New `Action.IMPERSONATE_USER` (resource-specific on `USER`), granted to
  `OPERATIONS_ADMIN`; `GENERAL_ADMIN` inherits it. No other role gets it.
- Optional `impersonatingUserId` audit claim on the token payload/contents.
- New `PostImpersonateUserResponse` schema.

**API (`@faims3/api`)**
- `POST /api/users/:id/impersonate`, gated by `IMPERSONATE_USER`, returning an
  `{accessToken, refreshToken}` pair for the target.
- Safety rails: cannot impersonate yourself, a disabled account, or a
  `GENERAL_ADMIN`.
- Token generation threads an `impersonatingUserId` audit claim (surfaced on
  `Express.User`) + a short refresh-token lifetime
  (`IMPERSONATION_SESSION_EXPIRY_MINUTES`, default 60m); audit log on start.

**Control Centre (`@faims3/web`)**
- "Impersonate" action in the admin user list (hidden for self, cluster admins,
  unauthorised users).
- Auth context stashes the admin's own session and swaps in the impersonated one;
  an expired impersonation refresh returns the admin to their own account.
- Amber banner with "Return to your account".

**Data-collection app (`@faims3/app`)** — self-contained, mirrors the web UX
- The app's multi-connection auth model is reused: impersonation stores the target
  as an **additional connection** on the active server, tagged with the admin's
  username (`impersonatingUser`), and makes it active. `authSlice` gains
  `startImpersonation`/`stopImpersonation` thunks + `selectIsImpersonating`; the
  marker is preserved across token refreshes.
- Account menu gains an "Impersonate user" item (gated by
  `globalRolesGrantAction(IMPERSONATE_USER)`), opening a searchable user-picker
  dialog (excludes self / cluster admins / disabled).
- App-wide warning banner with "Return to your account" restores the admin
  connection and removes the impersonated one (best-effort refresh-token logout).

**Tests**
- data-model (jest): role grants for `IMPERSONATE_USER`.
- API (mocha/supertest): happy path, authz denial, all safety rails, token
  identity + audit claim, refresh continuity (`api/test/impersonate.test.ts`).
- app (vitest): `authSlice` reducers (marker set + preserved across refresh,
  `selectIsImpersonating`) and `startImpersonation`/`stopImpersonation` thunks
  (`app/src/context/slices/authSlice.impersonation.test.ts`).

## How to Test

Automated:
- `pnpm --filter=@faims3/data-model test`
- `pnpm --filter=@faims3/api test -- --grep impersonation`
- `pnpm --filter=@faims3/app exec vitest --run src/context/slices/authSlice.impersonation.test.ts`

Manual — Control Centre: sign in as an ops/super admin → **Users** → mask icon on a
non-admin user → confirm → session swaps + amber banner → **Return to your account**.

Manual — App: sign in as an ops/super admin → account menu → **Impersonate user** →
pick a user → app shows their context with a banner → **Return to your account**.

### Verification performed
- data-model jest: 19 suites pass (incl. new permission tests).
- API mocha: 9 impersonation tests pass; full suite 353 pass.
- web `tsc --noEmit` clean for changed files; `turbo lint` 0 errors; oxfmt clean.
- app `tsc --noEmit` 0 errors; `turbo lint` 0 warnings/0 errors; oxfmt clean;
  vitest 8 pass (7 impersonation + existing appbarAuth); `vite build` succeeds.
- Live end-to-end against a running stack: admin `login → exchange → impersonate`
  returns a token authenticating as the target (`/api/users/current` = target) with
  `impersonatingUserId=admin`; negative cases `403`/`404`/`401` as expected; refresh
  maintains the session.

## Additional Information

- **Who can impersonate:** `OPERATIONS_ADMIN` (super users inherit). Restricting to
  super-users-only is a one-line change.
- **Known limitation:** the `impersonatingUserId` audit claim is not re-embedded on
  silent token refresh (would require a versioned refresh-token DB migration);
  mitigated by the short session expiry. In the app the impersonation marker is
  stored in Redux, so the banner/return are unaffected by claim loss on refresh.
- **App entry point:** self-contained in-app impersonation. A Control-Centre → app
  deep link is a possible future enhancement.

## Checklist

- [ ] I have confirmed all commits have been signed.
- [x] I have added JSDoc style comments to any new functions or classes.
- [x] Relevant documentation such as READMEs, guides, and class comments are updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8839339-5e44-44ca-bf2b-973d47553b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8839339-5e44-44ca-bf2b-973d47553b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

