### PR TITLE
feat(aws-cdk): always-on couch-auth-proxy on shared ALB

### DIFF
--- a/docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md
+++ b/docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md
@@ -318,7 +318,6 @@ Frontend CSP can keep `https://${domains.couch}` — hostname unchanged.
 
 ```json
 "couchAuthProxy": {
-  "enabled": true,
   "image": "ghcr.io/peterbaker0/couch-auth-proxy",
   "imageTag": "sha-3004091",
   "cpu": 512,
@@ -327,11 +326,9 @@ Frontend CSP can keep `https://${domains.couch}` — hostname unchanged.
 }
 ```
 
-Zod: required when present; pin `imageTag` in README next to data-model ACL
-ddoc version **2.3.0**.
-
-`enabled: false` preserves legacy “ALB → Couch” for emergency rollback only.
-Document that rollback re-opens the read gap.
+Zod: section optional only because field defaults apply when omitted; the
+proxy is **always deployed** (no `enabled` flag). Pin `imageTag` in README
+next to data-model ACL ddoc version **2.3.0**.
 
 ---
 
@@ -339,9 +336,9 @@ Document that rollback re-opens the read gap.
 
 Align with handover §13; infra-specific steps:
 
-1. **Deploy application build** that stamps ACL + DATA v1→v2 migration while
-   `couchAuthProxy.enabled` is still `false` (public URL still raw Couch) **or**
-   deploy code first with proxy not yet receiving traffic.
+1. **Deploy application build** that stamps ACL + DATA v1→v2 migration, and
+   run migrations against **internal** Couch **before** (or as part of)
+   directing production sync clients at the always-on proxy hostname.
 2. **Run migrations** (`MIGRATE_NOTEBOOKS_ON_STARTUP` / initialise) until every
    `data-*` is at version **2**. Optionally
    `pnpm --filter=@faims3/api run repair-data-db-acl`.
@@ -396,26 +393,21 @@ add “healthy host &lt; 1” on the proxy TG.
 [x] Add CouchAuthProxyConfig to config Zod schema + sample.json
 [x] Implement CouchAuthProxy ECS construct
 [x] Export couch SG + internalEndpoint from EC2CouchDB
-[x] Stop public ALB targeting Couch when proxy enabled
+[x] Stop public ALB targeting Couch (proxy always owns couch.*)
 [x] Split COUCHDB_PUBLIC_URL / COUCHDB_INTERNAL_URL in FaimsConductor
 [x] Wire SGs: proxy→5984, conductor→5984; deny ALB→5984
 [x] Health check on /_couch-auth-proxy/health
 [x] README + DeployingAWSStack.md cutover notes
-[x] cdk synth against sample config (enabled true/false)
+[x] Synth-level tests for always-on proxy wiring
+[x] Remove couchAuthProxy.enabled (proxy mandatory)
 [ ] cdk diff on a non-prod account (operator)
-[ ] Soak on staging hostname, then flip couch.* (operator)
+[ ] Soak on staging, then cut over production sync clients
 ```
 
-**CDK construct work is done.** Live cutover still requires DATA v2 migration
-on every `data-*` DB **before** setting `couchAuthProxy.enabled: true` — see
-[CouchAuthProxyCutover](CouchAuthProxyCutover.md). Do not flip a production
-account without that backfill.
-
-Suggested commit split (historical):
-
-1. Construct + config (proxy enabled but optional; no prod flip).
-2. Stack wiring + Conductor URL split behind `couchAuthProxy.enabled`.
-3. Docs / runbook only if not already covered here.
+**CDK construct work is done; proxy is always on.** Live cutover still
+requires DATA v2 migration on every `data-*` DB **before** production sync
+clients use the public hostname — see
+[CouchAuthProxyCutover](CouchAuthProxyCutover.md).
 
 ---
 

--- a/docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md
+++ b/docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md
@@ -393,19 +393,25 @@ add “healthy host &lt; 1” on the proxy TG.
 ## 9. Implementation checklist (follow-on coding PR)
 
 ```text
-[ ] Add CouchAuthProxyConfig to config Zod schema + sample.json
-[ ] Implement CouchAuthProxy ECS construct
-[ ] Export couch SG + internalEndpoint from EC2CouchDB
-[ ] Stop public ALB targeting Couch when proxy enabled
-[ ] Split COUCHDB_PUBLIC_URL / COUCHDB_INTERNAL_URL in FaimsConductor
-[ ] Wire SGs: proxy→5984, conductor→5984; deny ALB→5984
-[ ] Health check on /_couch-auth-proxy/health
-[ ] README + DeployingAWSStack.md cutover notes
-[ ] cdk synth against sample config; cdk diff on a non-prod account
-[ ] Soak on staging hostname, then flip couch.* 
+[x] Add CouchAuthProxyConfig to config Zod schema + sample.json
+[x] Implement CouchAuthProxy ECS construct
+[x] Export couch SG + internalEndpoint from EC2CouchDB
+[x] Stop public ALB targeting Couch when proxy enabled
+[x] Split COUCHDB_PUBLIC_URL / COUCHDB_INTERNAL_URL in FaimsConductor
+[x] Wire SGs: proxy→5984, conductor→5984; deny ALB→5984
+[x] Health check on /_couch-auth-proxy/health
+[x] README + DeployingAWSStack.md cutover notes
+[x] cdk synth against sample config (enabled true/false)
+[ ] cdk diff on a non-prod account (operator)
+[ ] Soak on staging hostname, then flip couch.* (operator)
 ```
 
-Suggested commit split:
+**CDK construct work is done.** Live cutover still requires DATA v2 migration
+on every `data-*` DB **before** setting `couchAuthProxy.enabled: true` — see
+[CouchAuthProxyCutover](CouchAuthProxyCutover.md). Do not flip a production
+account without that backfill.
+
+Suggested commit split (historical):
 
 1. Construct + config (proxy enabled but optional; no prod flip).
 2. Stack wiring + Conductor URL split behind `couchAuthProxy.enabled`.

--- a/docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md
+++ b/docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md
@@ -354,8 +354,9 @@ Align with handover §13; infra-specific steps:
 6. **Clients** rebuild local data DBs via `openLocalDataDbWithAclCutover` on
    next activate (app change already on proxy integration branch).
 
-Rollback: point ALB + `COUCHDB_PUBLIC_URL` back at Couch (accept read-gap
-regression) or scale proxy to 0 only after restoring Couch TG.
+Rollback is no longer a config flag (proxy is always on). Emergency
+recovery means a CDK change to re-attach a Couch TG / bypass the proxy
+(accept read-gap regression) — not an operator `enabled: false` toggle.
 
 ---
 
@@ -441,7 +442,7 @@ Conductor env must gain an internal Couch URL (currently only
 | Admin creds | Existing Secrets Manager secret |
 | ACL scope | `ACL_DB_INCLUDE=/^data-/`, `ACL_AUTO_INSTALL=false` |
 | Cutover gate | DATA v2 migration before ALB flip |
-| Rollback | Re-attach Couch TG (reopens read gap) |
+| Rollback | Code change to re-attach Couch TG (no `enabled` flag; reopens read gap) |
 
 ---
 

--- a/docs/developer/docs/source/markdown/DeployingAWSStack.md
+++ b/docs/developer/docs/source/markdown/DeployingAWSStack.md
@@ -755,15 +755,13 @@ Then add the following values to the bottom of the .env file:
 COUCHDB_USER=admin
 COUCHDB_PASSWORD="<YOUR DB PASSWORD>"
 COUCHDB_EXTERNAL_PORT=443
-# With couchAuthProxy.enabled=true the CDK stack sets these on Conductor:
+# The CDK stack always sets these on Conductor:
 #   PUBLIC  → https://<couch subdomain>.<domain>:443  (ALB → proxy)
 #   INTERNAL → http://<couch-private-ip>:5984         (VPC, admin Basic)
-# For local migrate against a deployed stack, use admin creds + INTERNAL URL
-# (or the public hostname only while the proxy is still disabled).
+# For local migrate against a deployed stack, use admin creds + INTERNAL URL.
 # See Authorisation/CouchAuthProxyAwsCdk.md and CouchAuthProxyCutover.md.
 COUCHDB_INTERNAL_URL=https://db.<your domain>:443
-# Public sync URL advertised to the app as dataDb.base_url.
-# After cutover this is the same hostname, terminated on couch-auth-proxy.
+# Public sync URL advertised to the app as dataDb.base_url (proxy hostname).
 COUCHDB_PUBLIC_URL=https://db.<your domain>:443
 AWS_DEFAULT_REGION=<your deployment region e.g. ap-southeast-2>
 KEY_SOURCE=AWS_SM
@@ -820,14 +818,12 @@ You can now manage the deployment with your personal login.
 
 ## couch-auth-proxy (per-document sync ACL)
 
-Public Pouch↔Couch sync should not hit CouchDB directly once guest my/all
-reads are enforced. The AWS CDK stack implements this behind
-`couchAuthProxy` in your config JSON (see
+Public Pouch↔Couch sync always goes through couch-auth-proxy in the AWS CDK
+stack. Tune the image/size via `couchAuthProxy` in your config JSON (see
 [infrastructure/aws-cdk/README.md](../../../../infrastructure/aws-cdk/README.md)):
 
 ```json
 "couchAuthProxy": {
-  "enabled": true,
   "image": "ghcr.io/peterbaker0/couch-auth-proxy",
   "imageTag": "sha-3004091",
   "cpu": 512,
@@ -836,18 +832,15 @@ reads are enforced. The AWS CDK stack implements this behind
 }
 ```
 
-When `enabled` is `true`:
+Always-on topology:
 
 - public `couch.*` / `db.*` hostname on the shared ALB → **couch-auth-proxy** ECS
 - Conductor `COUCHDB_PUBLIC_URL` → that hostname; `COUCHDB_INTERNAL_URL` → VPC Couch
 - Couch `:5984` is **not** registered on the internet-facing ALB (SG: proxy + Conductor only)
 
-When `enabled` is `false`, legacy ALB→Couch is preserved (emergency rollback only;
-that reopens the guest sync read gap).
-
-**Mandatory order:** migrate every `data-*` DB to version **2** (stamp ACL +
-`_design/acl`) **before** setting `enabled: true` on a live environment.
-Flipping the public URL first leaves unstamped docs world-readable to members.
+**First-deploy order:** migrate every `data-*` DB to version **2** (stamp ACL +
+`_design/acl`) **before** sending production sync traffic at the proxy.
+Unstamped docs are world-readable to members under the proxy.
 
 Design / CDK details: [CouchAuthProxyAwsCdk](Authorisation/CouchAuthProxyAwsCdk.md).  
 Operator runbook: [CouchAuthProxyCutover](Authorisation/CouchAuthProxyCutover.md).

--- a/docs/developer/docs/source/markdown/DeployingAWSStack.md
+++ b/docs/developer/docs/source/markdown/DeployingAWSStack.md
@@ -755,15 +755,15 @@ Then add the following values to the bottom of the .env file:
 COUCHDB_USER=admin
 COUCHDB_PASSWORD="<YOUR DB PASSWORD>"
 COUCHDB_EXTERNAL_PORT=443
-# Today both may still point at the public Couch hostname. After
-# couch-auth-proxy cutover: PUBLIC_URL → proxy (same hostname), INTERNAL_URL →
-# VPC-only Couch. See Authorisation/CouchAuthProxyAwsCdk.md.
-COUCHDB_INTERNAL_URL=https://db.<your domain>:443/
+# With couchAuthProxy.enabled=true the CDK stack sets these on Conductor:
+#   PUBLIC  → https://<couch subdomain>.<domain>:443  (ALB → proxy)
+#   INTERNAL → http://<couch-private-ip>:5984         (VPC, admin Basic)
+# For local migrate against a deployed stack, use admin creds + INTERNAL URL
+# (or the public hostname only while the proxy is still disabled).
+# See Authorisation/CouchAuthProxyAwsCdk.md and CouchAuthProxyCutover.md.
+COUCHDB_INTERNAL_URL=https://db.<your domain>:443
 # Public sync URL advertised to the app as dataDb.base_url.
-# For per-document guest ACL this MUST be couch-auth-proxy, not raw Couch.
-# See docs/.../Authorisation/CouchAuthProxyCutover.md for the cutover sequence.
-# (AWS CDK may still wire this to the Couch endpoint today — update infra
-# before relying on sync isolation in production.)
+# After cutover this is the same hostname, terminated on couch-auth-proxy.
 COUCHDB_PUBLIC_URL=https://db.<your domain>:443
 AWS_DEFAULT_REGION=<your deployment region e.g. ap-southeast-2>
 KEY_SOURCE=AWS_SM
@@ -821,16 +821,36 @@ You can now manage the deployment with your personal login.
 ## couch-auth-proxy (per-document sync ACL)
 
 Public Pouch↔Couch sync should not hit CouchDB directly once guest my/all
-reads are enforced. The intended AWS shape is:
+reads are enforced. The AWS CDK stack implements this behind
+`couchAuthProxy` in your config JSON (see
+[infrastructure/aws-cdk/README.md](../../../../infrastructure/aws-cdk/README.md)):
 
-- public `couch.*` / `db.*` hostname on the shared ALB → **couch-auth-proxy**
-- Conductor admin traffic → Couch on a **VPC-internal** URL
-- Couch `:5984` not registered on the internet-facing ALB
+```json
+"couchAuthProxy": {
+  "enabled": true,
+  "image": "ghcr.io/peterbaker0/couch-auth-proxy",
+  "imageTag": "sha-3004091",
+  "cpu": 512,
+  "memory": 1024,
+  "desiredCount": 2
+}
+```
 
-Design, CDK construct sketch, security groups, config schema, and infra
-cutover order: [CouchAuthProxyAwsCdk](Authorisation/CouchAuthProxyAwsCdk.md).
-Operator runbook (migrations before flipping the public URL):
-[CouchAuthProxyCutover](Authorisation/CouchAuthProxyCutover.md).
+When `enabled` is `true`:
+
+- public `couch.*` / `db.*` hostname on the shared ALB → **couch-auth-proxy** ECS
+- Conductor `COUCHDB_PUBLIC_URL` → that hostname; `COUCHDB_INTERNAL_URL` → VPC Couch
+- Couch `:5984` is **not** registered on the internet-facing ALB (SG: proxy + Conductor only)
+
+When `enabled` is `false`, legacy ALB→Couch is preserved (emergency rollback only;
+that reopens the guest sync read gap).
+
+**Mandatory order:** migrate every `data-*` DB to version **2** (stamp ACL +
+`_design/acl`) **before** setting `enabled: true` on a live environment.
+Flipping the public URL first leaves unstamped docs world-readable to members.
+
+Design / CDK details: [CouchAuthProxyAwsCdk](Authorisation/CouchAuthProxyAwsCdk.md).  
+Operator runbook: [CouchAuthProxyCutover](Authorisation/CouchAuthProxyCutover.md).
 
 ## Additional configurations
 

--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -24,13 +24,13 @@ The `EC2CouchDB` construct deploys CouchDB:
 - **Cloud Watch**: Includes a set of monitoring alarms triggering SNS topics, subscribed to an email address. Cloudwatch agent is installed and configured on instance. Logs collected and reported to /ec2/couchdb log stream.
 - **Secrets Manager**: Stores CouchDB admin credentials.
 - **Custom Configuration**: Sets up CouchDB with specific settings, including CORS and authentication handlers.
-- **Load Balancer Integration**: When `couchAuthProxy.enabled` is **false** (legacy/rollback), registers the instance on the shared ALB for `couch.*`. When the proxy is **enabled**, Couch is **not** on the public ALB; only proxy + Conductor security groups may reach `:5984`.
-- **DNS**: Creates a custom domain alias to the shared ALB (hostname unchanged for CSP/clients).
+- **Load Balancer Integration**: Couch is **not** on the public ALB; only proxy + Conductor security groups may reach `:5984`.
+- **DNS**: Creates a custom domain alias to the shared ALB (hostname unchanged for CSP/clients; traffic terminates on couch-auth-proxy).
 - **Internal endpoint**: Exposes `internalEndpoint` (`http://<private-ip>:5984`) for Conductor admin and the proxy.
 
-### couch-auth-proxy (public sync ACL)
+### couch-auth-proxy (public sync ACL — always on)
 
-The `CouchAuthProxy` construct (gated by `couchAuthProxy.enabled`) deploys
+The `CouchAuthProxy` construct always deploys
 [`couch-auth-proxy`](https://github.com/PeterBaker0/couch-auth-proxy) as ECS
 Fargate on the shared ALB:
 
@@ -45,8 +45,9 @@ Fargate on the shared ALB:
   (must match vendored `_design/acl` ddoc **2.3.0** in `@faims3/data-model` /
   `docker-compose.yml`).
 
-**Cutover gate:** Do not set `enabled: true` on a live environment until every
-`data-*` DB is at migration version **2**. Order and rollback:
+**First-deploy gate:** ensure every `data-*` DB is at migration version **2**
+before pointing production traffic at a new stack (unstamped docs are
+world-readable to members under the proxy). See
 [CouchAuthProxyCutover](../../docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyCutover.md),
 [CouchAuthProxyAwsCdk](../../docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md).
 
@@ -56,9 +57,8 @@ The `FaimsConductor` construct sets up the API service:
 
 - **ECS Fargate**: Runs the Conductor API as a containerized service. Can either be built using CDK with a debug flag in the code, or preferably use a docker hub image (name and tag).
 - **Task Definition**: Configures the container with environment variables and secrets.
-- **Couch URLs**: `COUCHDB_PUBLIC_URL` (apps / sync — proxy when enabled) vs
-  `COUCHDB_INTERNAL_URL` (admin — VPC Couch when proxy enabled; same public
-  hostname in legacy mode).
+- **Couch URLs**: `COUCHDB_PUBLIC_URL` (apps / sync → proxy) vs
+  `COUCHDB_INTERNAL_URL` (admin → VPC Couch).
 - **Load Balancer Integration**: Uses the shared ALB with a dedicated target group.
 - **Auto Scaling**: Configures service auto-scaling based on memory usage and CPU usage.
 - **Secrets**: Utilizes AWS Secrets Manager for sensitive data like cookie secrets and database credentials.
@@ -392,12 +392,10 @@ Note that this validation is at a schema level, it might not catch improperly fo
     - `http5xx`: (Optional) HTTP 5xx errors alarm settings (same structure as cpu, but threshold is count of errors)
     - `alarmTopic`: (Optional) SNS topic settings for alarms
       - `emailAddress`: Email address to send alarm notifications
-- `couchAuthProxy`: (Optional) Public Pouch sync ACL proxy. Defaults to
-  `{ "enabled": false }` (legacy ALB → Couch). **Do not enable in production
-  until DATA v2 migration completes** — see CouchAuthProxyCutover.md.
-  - `enabled`: When `true`, ALB `couch.*` → ECS proxy; Conductor
-    `COUCHDB_INTERNAL_URL` → VPC Couch; Couch SG allows proxy + Conductor only.
-    When `false`, preserves legacy ALB→Couch (rollback; reopens guest read gap).
+- `couchAuthProxy`: Public Pouch sync ACL proxy (**always deployed**). Section
+  is optional in JSON only because image/cpu defaults apply when omitted.
+  Complete DATA v2 migration before first production deploy — see
+  CouchAuthProxyCutover.md.
   - `image`: (default `ghcr.io/peterbaker0/couch-auth-proxy`) Image repository
   - `imageTag`: (default `sha-3004091`) Immutable pin matching data-model ACL
     ddoc **2.3.0** / compose

--- a/infrastructure/aws-cdk/README.md
+++ b/infrastructure/aws-cdk/README.md
@@ -24,8 +24,31 @@ The `EC2CouchDB` construct deploys CouchDB:
 - **Cloud Watch**: Includes a set of monitoring alarms triggering SNS topics, subscribed to an email address. Cloudwatch agent is installed and configured on instance. Logs collected and reported to /ec2/couchdb log stream.
 - **Secrets Manager**: Stores CouchDB admin credentials.
 - **Custom Configuration**: Sets up CouchDB with specific settings, including CORS and authentication handlers.
-- **Load Balancer Integration**: Uses the shared ALB with a dedicated target group. Will support clustering in the future and performs TLS termination.
-- **DNS**: Creates a custom domain for CouchDB access.
+- **Load Balancer Integration**: When `couchAuthProxy.enabled` is **false** (legacy/rollback), registers the instance on the shared ALB for `couch.*`. When the proxy is **enabled**, Couch is **not** on the public ALB; only proxy + Conductor security groups may reach `:5984`.
+- **DNS**: Creates a custom domain alias to the shared ALB (hostname unchanged for CSP/clients).
+- **Internal endpoint**: Exposes `internalEndpoint` (`http://<private-ip>:5984`) for Conductor admin and the proxy.
+
+### couch-auth-proxy (public sync ACL)
+
+The `CouchAuthProxy` construct (gated by `couchAuthProxy.enabled`) deploys
+[`couch-auth-proxy`](https://github.com/PeterBaker0/couch-auth-proxy) as ECS
+Fargate on the shared ALB:
+
+- **Public hostname**: Same `couch.<baseDomain>` as before (no app/CSP rebuild).
+- **ALB**: Host rule → proxy target group on `:8000`; health check
+  `/_couch-auth-proxy/health`.
+- **Upstream**: VPC HTTP to Couch `internalEndpoint`; admin creds via Secrets Manager.
+- **Hardened env**: `ACL_DB_INCLUDE=/^data-/`, `ACL_ROUTE_INCLUDE=pouch-sync,session`,
+  `ACL_AUTO_INSTALL=false`, `AUTH_RESOLVE_VIA_COUCH_SESSION=true`,
+  `CORS_ORIGINS` from faims+web domains.
+- **Image pin**: Default `ghcr.io/peterbaker0/couch-auth-proxy:sha-3004091`
+  (must match vendored `_design/acl` ddoc **2.3.0** in `@faims3/data-model` /
+  `docker-compose.yml`).
+
+**Cutover gate:** Do not set `enabled: true` on a live environment until every
+`data-*` DB is at migration version **2**. Order and rollback:
+[CouchAuthProxyCutover](../../docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyCutover.md),
+[CouchAuthProxyAwsCdk](../../docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md).
 
 ### Conductor (API Service)
 
@@ -33,6 +56,9 @@ The `FaimsConductor` construct sets up the API service:
 
 - **ECS Fargate**: Runs the Conductor API as a containerized service. Can either be built using CDK with a debug flag in the code, or preferably use a docker hub image (name and tag).
 - **Task Definition**: Configures the container with environment variables and secrets.
+- **Couch URLs**: `COUCHDB_PUBLIC_URL` (apps / sync — proxy when enabled) vs
+  `COUCHDB_INTERNAL_URL` (admin — VPC Couch when proxy enabled; same public
+  hostname in legacy mode).
 - **Load Balancer Integration**: Uses the shared ALB with a dedicated target group.
 - **Auto Scaling**: Configures service auto-scaling based on memory usage and CPU usage.
 - **Secrets**: Utilizes AWS Secrets Manager for sensitive data like cookie secrets and database credentials.
@@ -366,6 +392,18 @@ Note that this validation is at a schema level, it might not catch improperly fo
     - `http5xx`: (Optional) HTTP 5xx errors alarm settings (same structure as cpu, but threshold is count of errors)
     - `alarmTopic`: (Optional) SNS topic settings for alarms
       - `emailAddress`: Email address to send alarm notifications
+- `couchAuthProxy`: (Optional) Public Pouch sync ACL proxy. Defaults to
+  `{ "enabled": false }` (legacy ALB → Couch). **Do not enable in production
+  until DATA v2 migration completes** — see CouchAuthProxyCutover.md.
+  - `enabled`: When `true`, ALB `couch.*` → ECS proxy; Conductor
+    `COUCHDB_INTERNAL_URL` → VPC Couch; Couch SG allows proxy + Conductor only.
+    When `false`, preserves legacy ALB→Couch (rollback; reopens guest read gap).
+  - `image`: (default `ghcr.io/peterbaker0/couch-auth-proxy`) Image repository
+  - `imageTag`: (default `sha-3004091`) Immutable pin matching data-model ACL
+    ddoc **2.3.0** / compose
+  - `cpu`: (default `512`) Fargate CPU units
+  - `memory`: (default `1024`) Fargate memory MiB
+  - `desiredCount`: (default `2`) Desired task count
 - `conductor`: Configuration for the Conductor API service.
   - `name`: Title for this conductor instance (e.g. shown on listings page)
   - `description`: Subheading or description for the instance

--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -87,7 +87,6 @@
     }
   },
   "couchAuthProxy": {
-    "enabled": true,
     "image": "ghcr.io/peterbaker0/couch-auth-proxy",
     "imageTag": "sha-3004091",
     "cpu": 512,

--- a/infrastructure/aws-cdk/configs/sample.json
+++ b/infrastructure/aws-cdk/configs/sample.json
@@ -86,6 +86,14 @@
       }
     }
   },
+  "couchAuthProxy": {
+    "enabled": true,
+    "image": "ghcr.io/peterbaker0/couch-auth-proxy",
+    "imageTag": "sha-3004091",
+    "cpu": 512,
+    "memory": 1024,
+    "desiredCount": 2
+  },
   "backup": {
     "vaultName": "faims-backup-vault",
     "retentionDays": 30,

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -77,10 +77,20 @@ export interface FaimsConductorProps {
   certificate: acm.ICertificate;
   /** CouchDB admin user/password secret */
   couchDbAdminSecret: sm.Secret;
-  /** CouchDB port (external) */
+  /** CouchDB port (external / ALB), used as COUCHDB_EXTERNAL_PORT */
   couchDBPort: number;
-  /** CouchDB endpoint (format: https://domain:port) */
-  couchDBEndpoint: string;
+  /**
+   * Public Couch URL advertised to apps as dataDb.base_url
+   * (`COUCHDB_PUBLIC_URL`). After cutover this is the couch-auth-proxy
+   * hostname (same public host as before).
+   */
+  couchDBPublicEndpoint: string;
+  /**
+   * VPC-internal Couch URL for Conductor admin traffic
+   * (`COUCHDB_INTERNAL_URL`). After cutover this is http://PRIVATE_IP:5984
+   * and must bypass the proxy.
+   */
+  couchDBInternalEndpoint: string;
   /** Public URL for the /web (new conductor) */
   webUrl: string;
   /** Public URL for web app */
@@ -137,6 +147,8 @@ export class FaimsConductor extends Construct {
   public readonly conductorEndpoint: string;
   /** The Fargate Service */
   public readonly fargateService: ecs.FargateService;
+  /** Security group attached to the service (for Couch ingress) */
+  public readonly serviceSecurityGroup: ec2.SecurityGroup;
 
   constructor(scope: Construct, id: string, props: FaimsConductorProps) {
     super(scope, id);
@@ -258,10 +270,11 @@ export class FaimsConductor extends Construct {
         CONDUCTOR_INSTANCE_NAME: props.config.name,
         CONDUCTOR_DESCRIPTION: props.config.description,
         COUCHDB_EXTERNAL_PORT: `${props.couchDBPort}`,
-        // TODO(couch-auth-proxy): point at the proxy hostname, not raw Couch.
-        // See docs/developer/.../Authorisation/CouchAuthProxyCutover.md
-        COUCHDB_PUBLIC_URL: props.couchDBEndpoint,
-        COUCHDB_INTERNAL_URL: props.couchDBEndpoint,
+        // PUBLIC → proxy (or legacy Couch when couchAuthProxy.enabled=false)
+        // INTERNAL → VPC Couch for admin / migrations (bypass proxy)
+        // See docs/.../Authorisation/CouchAuthProxyCutover.md
+        COUCHDB_PUBLIC_URL: props.couchDBPublicEndpoint,
+        COUCHDB_INTERNAL_URL: props.couchDBInternalEndpoint,
         CONDUCTOR_SHORT_CODE_PREFIX: props.config.shortCodePrefix,
         // Conductor API URLs
         CONDUCTOR_PUBLIC_URL: this.conductorEndpoint,
@@ -367,7 +380,7 @@ export class FaimsConductor extends Construct {
     });
 
     // Create Security Group for the Fargate service
-    const serviceSecurityGroup = new ec2.SecurityGroup(
+    this.serviceSecurityGroup = new ec2.SecurityGroup(
       this,
       'ConductorServiceSG',
       {
@@ -383,7 +396,7 @@ export class FaimsConductor extends Construct {
       taskDefinition: conductorTaskDfn,
       // Target number of tasks to run
       desiredCount: props.config.autoScaling.desiredCapacity,
-      securityGroups: [serviceSecurityGroup],
+      securityGroups: [this.serviceSecurityGroup],
       assignPublicIp: true, // TODO Change this if using private subnets with NAT
     });
 
@@ -479,7 +492,7 @@ export class FaimsConductor extends Construct {
     // ================
 
     // Allow inbound traffic from the ALB
-    serviceSecurityGroup.connections.allowFrom(
+    this.serviceSecurityGroup.connections.allowFrom(
       props.sharedBalancer.alb,
       ec2.Port.tcp(this.internalPort),
       'Allow traffic from ALB to Conductor Fargate Service'

--- a/infrastructure/aws-cdk/lib/components/conductor.ts
+++ b/infrastructure/aws-cdk/lib/components/conductor.ts
@@ -270,8 +270,7 @@ export class FaimsConductor extends Construct {
         CONDUCTOR_INSTANCE_NAME: props.config.name,
         CONDUCTOR_DESCRIPTION: props.config.description,
         COUCHDB_EXTERNAL_PORT: `${props.couchDBPort}`,
-        // PUBLIC → proxy (or legacy Couch when couchAuthProxy.enabled=false)
-        // INTERNAL → VPC Couch for admin / migrations (bypass proxy)
+        // PUBLIC → couch-auth-proxy; INTERNAL → VPC Couch (admin / migrations)
         // See docs/.../Authorisation/CouchAuthProxyCutover.md
         COUCHDB_PUBLIC_URL: props.couchDBPublicEndpoint,
         COUCHDB_INTERNAL_URL: props.couchDBInternalEndpoint,

--- a/infrastructure/aws-cdk/lib/components/couch-auth-proxy.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-auth-proxy.ts
@@ -1,0 +1,192 @@
+/*
+ * ECS Fargate couch-auth-proxy on the shared ALB (public couch.* hostname).
+ *
+ * See docs/developer/docs/source/markdown/Authorisation/CouchAuthProxyAwsCdk.md
+ */
+
+import {Duration} from 'aws-cdk-lib';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
+import {Construct} from 'constructs';
+import {SharedBalancer} from './networking';
+
+/**
+ * Properties for the CouchAuthProxy construct
+ */
+export interface CouchAuthProxyProps {
+  /** VPC to produce ECS cluster in */
+  vpc: ec2.IVpc;
+  /** Shared balancer to use */
+  sharedBalancer: SharedBalancer;
+  /** Public Couch hostname (same as before cutover), e.g. couch.example.com */
+  domainName: string;
+  /** The DNS certificate to use for Load Balancer */
+  certificate: acm.ICertificate;
+  /** Internal Couch base URL, e.g. http://10.0.x.x:5984 */
+  couchInternalUrl: string;
+  /** CouchDB admin user/password secret (username + password keys) */
+  couchAdminSecret: sm.ISecret;
+  /** SG on the Couch EC2 instance — receives ingress from this service */
+  couchSecurityGroup: ec2.ISecurityGroup;
+  /** Allowed CORS origins (app + web) */
+  corsOrigins: string[];
+  /** Container image repository (no tag) */
+  image: string;
+  /** Immutable image tag / digest pin */
+  imageTag: string;
+  /** Fargate CPU units */
+  cpu: number;
+  /** Fargate memory in MiB */
+  memory: number;
+  /** Desired task count */
+  desiredCount: number;
+  /** CouchDB internal port (default 5984) */
+  couchInternalPort?: number;
+}
+
+/**
+ * Fargate service that terminates public Pouch sync on the shared ALB and
+ * proxies ACL-filtered requests to VPC-internal CouchDB.
+ */
+export class CouchAuthProxy extends Construct {
+  /** Internal container port */
+  public readonly internalPort: number = 8000;
+  /** External HTTPS port on the ALB */
+  public readonly externalPort: number = 443;
+  /** Public HTTPS endpoint (format: https://domain:443) */
+  public readonly publicEndpoint: string;
+  /** The Fargate service */
+  public readonly service: ecs.FargateService;
+  /** Security group attached to the service (for Couch ingress) */
+  public readonly serviceSecurityGroup: ec2.SecurityGroup;
+  /** ALB target group */
+  public readonly targetGroup: elb.ApplicationTargetGroup;
+
+  constructor(scope: Construct, id: string, props: CouchAuthProxyProps) {
+    super(scope, id);
+
+    const couchPort = props.couchInternalPort ?? 5984;
+
+    this.publicEndpoint = `https://${props.domainName}:${this.externalPort}`;
+
+    const taskDefinition = new ecs.FargateTaskDefinition(
+      this,
+      'couch-auth-proxy-task-dfn',
+      {
+        cpu: props.cpu,
+        memoryLimitMiB: props.memory,
+      }
+    );
+
+    taskDefinition.addContainer('couch-auth-proxy-container', {
+      image: ecs.ContainerImage.fromRegistry(
+        `${props.image}:${props.imageTag}`
+      ),
+      portMappings: [
+        {
+          containerPort: this.internalPort,
+          appProtocol: ecs.AppProtocol.http,
+          name: 'couch-auth-proxy-port',
+        },
+      ],
+      environment: {
+        COUCH_URL: props.couchInternalUrl,
+        // Harden ACL scope — never ACL people/projects/auth DBs
+        ACL_DB_INCLUDE: '/^data-/',
+        ACL_ROUTE_INCLUDE: 'pouch-sync,session',
+        // FAIMS provisions `_design/acl` via init / DATA migration
+        ACL_AUTO_INSTALL: 'false',
+        AUTH_RESOLVE_VIA_COUCH_SESSION: 'true',
+        CORS_ORIGINS: props.corsOrigins.join(','),
+        PORT: `${this.internalPort}`,
+        HOST: '0.0.0.0',
+      },
+      secrets: {
+        COUCH_ADMIN_USER: ecs.Secret.fromSecretsManager(
+          props.couchAdminSecret,
+          'username'
+        ),
+        COUCH_ADMIN_PASSWORD: ecs.Secret.fromSecretsManager(
+          props.couchAdminSecret,
+          'password'
+        ),
+      },
+      logging: ecs.LogDriver.awsLogs({
+        streamPrefix: 'couch-auth-proxy',
+        logRetention: logs.RetentionDays.ONE_MONTH,
+      }),
+    });
+
+    props.couchAdminSecret.grantRead(taskDefinition.taskRole);
+
+    const cluster = new ecs.Cluster(this, 'CouchAuthProxyCluster', {
+      vpc: props.vpc,
+    });
+
+    this.serviceSecurityGroup = new ec2.SecurityGroup(
+      this,
+      'CouchAuthProxyServiceSG',
+      {
+        vpc: props.vpc,
+        allowAllOutbound: true,
+        description: 'Security group for couch-auth-proxy Fargate service',
+      }
+    );
+
+    this.service = new ecs.FargateService(this, 'couch-auth-proxy-service', {
+      cluster,
+      taskDefinition,
+      desiredCount: props.desiredCount,
+      securityGroups: [this.serviceSecurityGroup],
+      // Same as Conductor: public subnets, no NAT in this stack
+      assignPublicIp: true,
+    });
+
+    this.targetGroup = new elb.ApplicationTargetGroup(
+      this,
+      'CouchAuthProxyTG',
+      {
+        port: this.internalPort,
+        protocol: elb.ApplicationProtocol.HTTP,
+        targetType: elb.TargetType.IP,
+        healthCheck: {
+          enabled: true,
+          healthyHttpCodes: '200',
+          protocol: elb.Protocol.HTTP,
+          interval: Duration.seconds(30),
+          timeout: Duration.seconds(5),
+          port: this.internalPort.toString(),
+          path: '/_couch-auth-proxy/health',
+        },
+        vpc: props.vpc,
+      }
+    );
+
+    this.targetGroup.addTarget(this.service);
+
+    // Own the public couch.* host rule (same priority Couch used previously)
+    props.sharedBalancer.addHttpRedirectedConditionalHttpsTarget(
+      'couch',
+      this.targetGroup,
+      [elb.ListenerCondition.hostHeaders([props.domainName])],
+      110,
+      110
+    );
+
+    this.serviceSecurityGroup.connections.allowFrom(
+      props.sharedBalancer.alb,
+      ec2.Port.tcp(this.internalPort),
+      'Allow traffic from ALB to couch-auth-proxy'
+    );
+
+    props.couchSecurityGroup.connections.allowFrom(
+      this.serviceSecurityGroup,
+      ec2.Port.tcp(couchPort),
+      'Allow couch-auth-proxy to CouchDB'
+    );
+  }
+}

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -19,8 +19,6 @@ import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import {GraphWidget, Metric, TextWidget} from 'aws-cdk-lib/aws-cloudwatch';
 import * as cw_actions from 'aws-cdk-lib/aws-cloudwatch-actions';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import * as elbTargets from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as r53targets from 'aws-cdk-lib/aws-route53-targets';
@@ -59,12 +57,6 @@ export interface EC2CouchDBProps {
   couchVersionTag: string;
   /** chttpd_auth.secret configuration value - injected into init file */
   cookieSecret: sm.Secret;
-  /**
-   * When true (default), register this instance on the shared ALB for
-   * `domainName` (legacy public Couch). Set false when couch-auth-proxy owns
-   * the public host rule — DNS alias to the ALB is still created here.
-   */
-  attachToPublicAlb?: boolean;
 }
 
 /**
@@ -74,8 +66,7 @@ export class EC2CouchDB extends Construct {
   /** The EC2 instance running CouchDB */
   public readonly instance: ec2.Instance;
   /**
-   * Public HTTPS endpoint for the couch hostname (ALB). After proxy cutover
-   * this hostname terminates on couch-auth-proxy, not this instance.
+   * Public HTTPS endpoint for the couch hostname (ALB → couch-auth-proxy).
    */
   public readonly couchEndpoint: string;
   /**
@@ -89,10 +80,8 @@ export class EC2CouchDB extends Construct {
   public readonly exposedPort: number = 443;
   /** The secret containing the CouchDB admin user/password */
   public readonly passwordSecret: sm.Secret;
-  /** Shared ALB */
+  /** Shared ALB (DNS alias only; proxy owns the host rule) */
   private readonly sharedBalancer: SharedBalancer;
-  /** EC2 Target group (only when attachToPublicAlb) */
-  private readonly targetGroup?: elb.ApplicationTargetGroup;
   /** The internal port CouchDB listens on */
   public readonly couchInternalPort: number = 5984;
   /** The path where CouchDB data will be stored */
@@ -157,7 +146,6 @@ methods = GET, PUT, POST, HEAD, DELETE
     // Expose variables
     this.sharedBalancer = props.sharedBalancer;
     this.monitoringConfig = props.monitoring;
-    const attachToPublicAlb = props.attachToPublicAlb !== false;
 
     // AUXILIARY SETUP
     // ================
@@ -433,53 +421,11 @@ EOL`,
       }
     );
 
-    // LOAD BALANCING SETUP
-    // =========================
-    // When couch-auth-proxy is enabled, the proxy construct owns the public
-    // ALB host rule for domainName. We still publish DNS to the shared ALB.
-
-    if (attachToPublicAlb) {
-      // Create the target group for the CouchDB instances (legacy public path)
-      this.targetGroup = new elb.ApplicationTargetGroup(this, 'CouchTG', {
-        port: this.couchInternalPort,
-        protocol: elb.ApplicationProtocol.HTTP,
-        targetType: elb.TargetType.INSTANCE,
-        healthCheck: {
-          enabled: true,
-          healthyHttpCodes: '200',
-          protocol: elb.Protocol.HTTP,
-          interval: Duration.seconds(30),
-          timeout: Duration.seconds(5),
-          port: this.couchInternalPort.toString(),
-          path: '/',
-        },
-        vpc: props.vpc,
-      });
-
-      // Add the EC2 instance to the target group
-      this.targetGroup.addTarget(new elbTargets.InstanceTarget(this.instance));
-
-      // Add HTTP redirected HTTPS service to ALB against target group
-      props.sharedBalancer.addHttpRedirectedConditionalHttpsTarget(
-        'couch',
-        this.targetGroup,
-        [elb.ListenerCondition.hostHeaders([props.domainName])],
-        110, // TODO: Understand and consider priorities
-        110
-      );
-
-      // Allow inbound traffic from the ALB to the CouchDB instances
-      this.securityGroup.connections.allowFrom(
-        props.sharedBalancer.alb,
-        ec2.Port.tcp(this.couchInternalPort),
-        'Allow traffic from ALB to CouchDB instances'
-      );
-    }
-
     // DNS ROUTES
     // ===========
+    // Public couch.* DNS → shared ALB. The couch-auth-proxy construct owns the
+    // ALB host rule; this instance is not registered on the public ALB.
 
-    // Create a DNS record for the CouchDB endpoint (ALB; proxy or instance TG)
     new route53.ARecord(this, 'CouchDBAliasRecord', {
       zone: props.hz,
       recordName: props.domainName,
@@ -547,8 +493,7 @@ EOL`,
     // OUTPUTS
     // ================
 
-    // Public hostname (ALB). With proxy enabled, traffic terminates on the
-    // proxy TG registered against the same host rule / DNS.
+    // Public hostname (ALB → couch-auth-proxy).
     this.couchEndpoint = `https://${props.domainName}:${this.exposedPort}`;
     this.internalEndpoint = `http://${this.instance.instancePrivateIp}:${this.couchInternalPort}`;
     this.dataVolume = dataVolume;
@@ -664,30 +609,6 @@ EOL`,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       alarmDescription: 'CouchDB instance network out is high',
     });
-
-    // HTTP 5xx Errors Alarm (only when this construct owns the public TG)
-    if (this.targetGroup) {
-      this.createAlarm('CouchDBHttp5xxAlarm', {
-        metric: new cloudwatch.Metric({
-          namespace: 'AWS/ApplicationELB',
-          metricName: 'HTTPCode_Target_5XX_Count',
-          dimensionsMap: {
-            LoadBalancer: this.sharedBalancer.alb.loadBalancerFullName,
-            TargetGroup: this.targetGroup.targetGroupFullName,
-          },
-          statistic: 'Sum',
-          period: Duration.minutes(5),
-        }),
-        threshold: this.monitoringConfig?.http5xx?.threshold ?? 10,
-        evaluationPeriods:
-          this.monitoringConfig?.http5xx?.evaluationPeriods ?? 5,
-        datapointsToAlarm:
-          this.monitoringConfig?.http5xx?.datapointsToAlarm ?? 3,
-        comparisonOperator:
-          cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-        alarmDescription: 'CouchDB is returning a high number of 5xx errors',
-      });
-    }
   }
 
   /**
@@ -711,7 +632,6 @@ EOL`,
 
     const instanceId = this.instance.instanceId;
     const albFullName = this.sharedBalancer.alb.loadBalancerFullName;
-    const targetGroupFullName = this.targetGroup?.targetGroupFullName;
 
     // Helper function to create a left annotation for alarm thresholds
     const createLeftAnnotation = (value: number, label: string) => ({
@@ -886,61 +806,5 @@ EOL`,
         height: 6,
       })
     );
-
-    // Target-group widgets only when this construct owns the public Couch TG
-    if (targetGroupFullName) {
-      dashboard.addWidgets(
-        new GraphWidget({
-          title: 'ALB HTTP Error Codes',
-          left: [
-            new Metric({
-              namespace: 'AWS/ApplicationELB',
-              metricName: 'HTTPCode_Target_4XX_Count',
-              dimensionsMap: {
-                LoadBalancer: albFullName,
-                TargetGroup: targetGroupFullName,
-              },
-              statistic: 'Sum',
-              period: Duration.minutes(5),
-            }),
-            new Metric({
-              namespace: 'AWS/ApplicationELB',
-              metricName: 'HTTPCode_Target_5XX_Count',
-              dimensionsMap: {
-                LoadBalancer: albFullName,
-                TargetGroup: targetGroupFullName,
-              },
-              statistic: 'Sum',
-              period: Duration.minutes(5),
-            }),
-          ],
-          leftAnnotations: [
-            createLeftAnnotation(
-              this.monitoringConfig?.http5xx?.threshold ?? 10,
-              '5XX Error Alarm Threshold'
-            ),
-          ],
-          width: 8,
-          height: 6,
-        }),
-        new GraphWidget({
-          title: 'ALB Healthy Host Count',
-          left: [
-            new Metric({
-              namespace: 'AWS/ApplicationELB',
-              metricName: 'HealthyHostCount',
-              dimensionsMap: {
-                LoadBalancer: albFullName,
-                TargetGroup: targetGroupFullName,
-              },
-              statistic: 'Average',
-              period: Duration.minutes(5),
-            }),
-          ],
-          width: 12,
-          height: 6,
-        })
-      );
-    }
   }
 }

--- a/infrastructure/aws-cdk/lib/components/couch-db.ts
+++ b/infrastructure/aws-cdk/lib/components/couch-db.ts
@@ -59,6 +59,12 @@ export interface EC2CouchDBProps {
   couchVersionTag: string;
   /** chttpd_auth.secret configuration value - injected into init file */
   cookieSecret: sm.Secret;
+  /**
+   * When true (default), register this instance on the shared ALB for
+   * `domainName` (legacy public Couch). Set false when couch-auth-proxy owns
+   * the public host rule — DNS alias to the ALB is still created here.
+   */
+  attachToPublicAlb?: boolean;
 }
 
 /**
@@ -67,18 +73,28 @@ export interface EC2CouchDBProps {
 export class EC2CouchDB extends Construct {
   /** The EC2 instance running CouchDB */
   public readonly instance: ec2.Instance;
-  /** The public endpoint for accessing CouchDB */
+  /**
+   * Public HTTPS endpoint for the couch hostname (ALB). After proxy cutover
+   * this hostname terminates on couch-auth-proxy, not this instance.
+   */
   public readonly couchEndpoint: string;
-  /** The exposed HTTPS port */
+  /**
+   * VPC-internal HTTP endpoint for Conductor / proxy → Couch
+   * (format: http://PRIVATE_IP:5984)
+   */
+  public readonly internalEndpoint: string;
+  /** Security group on the Couch EC2 instance */
+  public readonly securityGroup: ec2.SecurityGroup;
+  /** The exposed HTTPS port (ALB) */
   public readonly exposedPort: number = 443;
   /** The secret containing the CouchDB admin user/password */
   public readonly passwordSecret: sm.Secret;
   /** Shared ALB */
   private readonly sharedBalancer: SharedBalancer;
-  /** EC2 Target group */
-  private readonly targetGroup: elb.ApplicationTargetGroup;
+  /** EC2 Target group (only when attachToPublicAlb) */
+  private readonly targetGroup?: elb.ApplicationTargetGroup;
   /** The internal port CouchDB listens on */
-  private readonly couchInternalPort: number = 5984;
+  public readonly couchInternalPort: number = 5984;
   /** The path where CouchDB data will be stored */
   private readonly couchDataPath: string = '/opt/couchdb/data';
   /** The device name for the EBS data volume */
@@ -141,6 +157,7 @@ methods = GET, PUT, POST, HEAD, DELETE
     // Expose variables
     this.sharedBalancer = props.sharedBalancer;
     this.monitoringConfig = props.monitoring;
+    const attachToPublicAlb = props.attachToPublicAlb !== false;
 
     // AUXILIARY SETUP
     // ================
@@ -360,15 +377,11 @@ EOL`,
     // ================
 
     // Create a security group for the EC2 instance
-    const couchSecurityGroup = new ec2.SecurityGroup(
-      this,
-      'CouchDBSecurityGroup',
-      {
-        vpc: props.vpc,
-        allowAllOutbound: true,
-        description: 'Security group for CouchDB EC2 instances',
-      }
-    );
+    this.securityGroup = new ec2.SecurityGroup(this, 'CouchDBSecurityGroup', {
+      vpc: props.vpc,
+      allowAllOutbound: true,
+      description: 'Security group for CouchDB EC2 instances',
+    });
 
     // Create the EC2 instance
     this.instance = new ec2.Instance(this, 'CouchDBInstance' + debugIdPostfix, {
@@ -386,7 +399,7 @@ EOL`,
       */
       userData,
       vpcSubnets: {subnetType: ec2.SubnetType.PUBLIC},
-      securityGroup: couchSecurityGroup,
+      securityGroup: this.securityGroup,
       instanceType: new ec2.InstanceType(props.instanceType),
     });
 
@@ -422,40 +435,51 @@ EOL`,
 
     // LOAD BALANCING SETUP
     // =========================
+    // When couch-auth-proxy is enabled, the proxy construct owns the public
+    // ALB host rule for domainName. We still publish DNS to the shared ALB.
 
-    // Create the target group for the CouchDB instances
-    this.targetGroup = new elb.ApplicationTargetGroup(this, 'CouchTG', {
-      port: this.couchInternalPort,
-      protocol: elb.ApplicationProtocol.HTTP,
-      targetType: elb.TargetType.INSTANCE,
-      healthCheck: {
-        enabled: true,
-        healthyHttpCodes: '200',
-        protocol: elb.Protocol.HTTP,
-        interval: Duration.seconds(30),
-        timeout: Duration.seconds(5),
-        port: this.couchInternalPort.toString(),
-        path: '/',
-      },
-      vpc: props.vpc,
-    });
+    if (attachToPublicAlb) {
+      // Create the target group for the CouchDB instances (legacy public path)
+      this.targetGroup = new elb.ApplicationTargetGroup(this, 'CouchTG', {
+        port: this.couchInternalPort,
+        protocol: elb.ApplicationProtocol.HTTP,
+        targetType: elb.TargetType.INSTANCE,
+        healthCheck: {
+          enabled: true,
+          healthyHttpCodes: '200',
+          protocol: elb.Protocol.HTTP,
+          interval: Duration.seconds(30),
+          timeout: Duration.seconds(5),
+          port: this.couchInternalPort.toString(),
+          path: '/',
+        },
+        vpc: props.vpc,
+      });
 
-    // Add the EC2 instance to the target group
-    this.targetGroup.addTarget(new elbTargets.InstanceTarget(this.instance));
+      // Add the EC2 instance to the target group
+      this.targetGroup.addTarget(new elbTargets.InstanceTarget(this.instance));
 
-    // Add HTTP redirected HTTPS service to ALB against target group
-    props.sharedBalancer.addHttpRedirectedConditionalHttpsTarget(
-      'couch',
-      this.targetGroup,
-      [elb.ListenerCondition.hostHeaders([props.domainName])],
-      110, // TODO: Understand and consider priorities
-      110
-    );
+      // Add HTTP redirected HTTPS service to ALB against target group
+      props.sharedBalancer.addHttpRedirectedConditionalHttpsTarget(
+        'couch',
+        this.targetGroup,
+        [elb.ListenerCondition.hostHeaders([props.domainName])],
+        110, // TODO: Understand and consider priorities
+        110
+      );
+
+      // Allow inbound traffic from the ALB to the CouchDB instances
+      this.securityGroup.connections.allowFrom(
+        props.sharedBalancer.alb,
+        ec2.Port.tcp(this.couchInternalPort),
+        'Allow traffic from ALB to CouchDB instances'
+      );
+    }
 
     // DNS ROUTES
     // ===========
 
-    // Create a DNS record for the CouchDB endpoint
+    // Create a DNS record for the CouchDB endpoint (ALB; proxy or instance TG)
     new route53.ARecord(this, 'CouchDBAliasRecord', {
       zone: props.hz,
       recordName: props.domainName,
@@ -472,7 +496,7 @@ EOL`,
 
     if (debugInstancePermissions) {
       // For debugging CouchDB instances - allow inbound traffic for SSM Instance Connect
-      couchSecurityGroup.addIngressRule(
+      this.securityGroup.addIngressRule(
         ec2.Peer.anyIpv4(),
         ec2.Port.tcp(443),
         'Allow SSM Instance Connect'
@@ -495,16 +519,6 @@ EOL`,
     // Add necessary permissions for CloudWatch agent
     this.instance.role.addManagedPolicy(
       iam.ManagedPolicy.fromAwsManagedPolicyName('CloudWatchAgentServerPolicy')
-    );
-
-    // NETWORK SECURITY
-    // ================
-
-    // Allow inbound traffic from the ALB to the CouchDB instances
-    couchSecurityGroup.connections.allowFrom(
-      props.sharedBalancer.alb,
-      ec2.Port.tcp(this.couchInternalPort),
-      'Allow traffic from ALB to CouchDB instances'
     );
 
     // MONITORING
@@ -533,8 +547,10 @@ EOL`,
     // OUTPUTS
     // ================
 
-    // Set the public endpoint for CouchDB
+    // Public hostname (ALB). With proxy enabled, traffic terminates on the
+    // proxy TG registered against the same host rule / DNS.
     this.couchEndpoint = `https://${props.domainName}:${this.exposedPort}`;
+    this.internalEndpoint = `http://${this.instance.instancePrivateIp}:${this.couchInternalPort}`;
     this.dataVolume = dataVolume;
   }
 
@@ -649,24 +665,29 @@ EOL`,
       alarmDescription: 'CouchDB instance network out is high',
     });
 
-    // HTTP 5xx Errors Alarm
-    this.createAlarm('CouchDBHttp5xxAlarm', {
-      metric: new cloudwatch.Metric({
-        namespace: 'AWS/ApplicationELB',
-        metricName: 'HTTPCode_Target_5XX_Count',
-        dimensionsMap: {
-          LoadBalancer: this.sharedBalancer.alb.loadBalancerFullName,
-          TargetGroup: this.targetGroup.targetGroupFullName,
-        },
-        statistic: 'Sum',
-        period: Duration.minutes(5),
-      }),
-      threshold: this.monitoringConfig?.http5xx?.threshold ?? 10,
-      evaluationPeriods: this.monitoringConfig?.http5xx?.evaluationPeriods ?? 5,
-      datapointsToAlarm: this.monitoringConfig?.http5xx?.datapointsToAlarm ?? 3,
-      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-      alarmDescription: 'CouchDB is returning a high number of 5xx errors',
-    });
+    // HTTP 5xx Errors Alarm (only when this construct owns the public TG)
+    if (this.targetGroup) {
+      this.createAlarm('CouchDBHttp5xxAlarm', {
+        metric: new cloudwatch.Metric({
+          namespace: 'AWS/ApplicationELB',
+          metricName: 'HTTPCode_Target_5XX_Count',
+          dimensionsMap: {
+            LoadBalancer: this.sharedBalancer.alb.loadBalancerFullName,
+            TargetGroup: this.targetGroup.targetGroupFullName,
+          },
+          statistic: 'Sum',
+          period: Duration.minutes(5),
+        }),
+        threshold: this.monitoringConfig?.http5xx?.threshold ?? 10,
+        evaluationPeriods:
+          this.monitoringConfig?.http5xx?.evaluationPeriods ?? 5,
+        datapointsToAlarm:
+          this.monitoringConfig?.http5xx?.datapointsToAlarm ?? 3,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        alarmDescription: 'CouchDB is returning a high number of 5xx errors',
+      });
+    }
   }
 
   /**
@@ -690,7 +711,7 @@ EOL`,
 
     const instanceId = this.instance.instanceId;
     const albFullName = this.sharedBalancer.alb.loadBalancerFullName;
-    const targetGroupFullName = this.targetGroup.targetGroupFullName;
+    const targetGroupFullName = this.targetGroup?.targetGroupFullName;
 
     // Helper function to create a left annotation for alarm thresholds
     const createLeftAnnotation = (value: number, label: string) => ({
@@ -851,56 +872,6 @@ EOL`,
         height: 6,
       }),
       new GraphWidget({
-        title: 'ALB HTTP Error Codes',
-        left: [
-          new Metric({
-            namespace: 'AWS/ApplicationELB',
-            metricName: 'HTTPCode_Target_4XX_Count',
-            dimensionsMap: {
-              LoadBalancer: albFullName,
-              TargetGroup: targetGroupFullName,
-            },
-            statistic: 'Sum',
-            period: Duration.minutes(5),
-          }),
-          new Metric({
-            namespace: 'AWS/ApplicationELB',
-            metricName: 'HTTPCode_Target_5XX_Count',
-            dimensionsMap: {
-              LoadBalancer: albFullName,
-              TargetGroup: targetGroupFullName,
-            },
-            statistic: 'Sum',
-            period: Duration.minutes(5),
-          }),
-        ],
-        leftAnnotations: [
-          createLeftAnnotation(
-            this.monitoringConfig?.http5xx?.threshold ?? 10,
-            '5XX Error Alarm Threshold'
-          ),
-        ],
-        width: 8,
-        height: 6,
-      }),
-      new GraphWidget({
-        title: 'ALB Healthy Host Count',
-        left: [
-          new Metric({
-            namespace: 'AWS/ApplicationELB',
-            metricName: 'HealthyHostCount',
-            dimensionsMap: {
-              LoadBalancer: albFullName,
-              TargetGroup: targetGroupFullName,
-            },
-            statistic: 'Average',
-            period: Duration.minutes(5),
-          }),
-        ],
-        width: 12,
-        height: 6,
-      }),
-      new GraphWidget({
         title: 'ALB Processed Bytes',
         left: [
           new Metric({
@@ -911,9 +882,65 @@ EOL`,
             period: Duration.minutes(5),
           }),
         ],
-        width: 12,
+        width: 8,
         height: 6,
       })
     );
+
+    // Target-group widgets only when this construct owns the public Couch TG
+    if (targetGroupFullName) {
+      dashboard.addWidgets(
+        new GraphWidget({
+          title: 'ALB HTTP Error Codes',
+          left: [
+            new Metric({
+              namespace: 'AWS/ApplicationELB',
+              metricName: 'HTTPCode_Target_4XX_Count',
+              dimensionsMap: {
+                LoadBalancer: albFullName,
+                TargetGroup: targetGroupFullName,
+              },
+              statistic: 'Sum',
+              period: Duration.minutes(5),
+            }),
+            new Metric({
+              namespace: 'AWS/ApplicationELB',
+              metricName: 'HTTPCode_Target_5XX_Count',
+              dimensionsMap: {
+                LoadBalancer: albFullName,
+                TargetGroup: targetGroupFullName,
+              },
+              statistic: 'Sum',
+              period: Duration.minutes(5),
+            }),
+          ],
+          leftAnnotations: [
+            createLeftAnnotation(
+              this.monitoringConfig?.http5xx?.threshold ?? 10,
+              '5XX Error Alarm Threshold'
+            ),
+          ],
+          width: 8,
+          height: 6,
+        }),
+        new GraphWidget({
+          title: 'ALB Healthy Host Count',
+          left: [
+            new Metric({
+              namespace: 'AWS/ApplicationELB',
+              metricName: 'HealthyHostCount',
+              dimensionsMap: {
+                LoadBalancer: albFullName,
+                TargetGroup: targetGroupFullName,
+              },
+              statistic: 'Average',
+              period: Duration.minutes(5),
+            }),
+          ],
+          width: 12,
+          height: 6,
+        })
+      );
+    }
   }
 }

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -380,6 +380,30 @@ const CouchConfigSchema = z.object({
   couchVersionTag: z.string().default('3.3.3'),
 });
 
+/**
+ * couch-auth-proxy (public Pouch sync ACL). Pin imageTag to the tag that
+ * matches vendored `_design/acl` in @faims3/data-model (ddoc 2.3.0) and
+ * docker-compose.yml. See CouchAuthProxyAwsCdk.md / CouchAuthProxyCutover.md.
+ *
+ * `enabled: false` keeps legacy ALB → Couch (rollback only; reopens the
+ * guest sync read gap). Do not enable in a live env until DATA DBs are at
+ * migration v2.
+ */
+const CouchAuthProxyConfigSchema = z.object({
+  /** When true, ALB couch.* → proxy; Conductor INTERNAL → VPC Couch */
+  enabled: z.boolean().default(false),
+  /** Container image repository (no tag) */
+  image: z.string().default('ghcr.io/peterbaker0/couch-auth-proxy'),
+  /** Immutable tag / digest pin (must match data-model ACL ddoc 2.3.0) */
+  imageTag: z.string().default('sha-3004091'),
+  /** Fargate CPU units */
+  cpu: z.number().int().positive().default(512),
+  /** Fargate memory in MiB */
+  memory: z.number().int().positive().default(1024),
+  /** Desired task count */
+  desiredCount: z.number().int().positive().default(2),
+});
+
 const DomainsConfigSchema = z.object({
   /** The base domain for all services. Note: Apex domains are not currently supported. */
   baseDomain: z.string(),
@@ -598,6 +622,18 @@ export const ConfigSchema = z.object({
   supportLinks: AppSupportLinksSchema,
   /** CouchDB configuration */
   couch: CouchConfigSchema,
+  /**
+   * Public sync ACL proxy. Optional; defaults to disabled (legacy ALB→Couch).
+   * Enable only after DATA v2 migration — see CouchAuthProxyCutover.md.
+   */
+  couchAuthProxy: CouchAuthProxyConfigSchema.optional().default({
+    enabled: false,
+    image: 'ghcr.io/peterbaker0/couch-auth-proxy',
+    imageTag: 'sha-3004091',
+    cpu: 512,
+    memory: 1024,
+    desiredCount: 2,
+  }),
   /** Backup configuration */
   backup: BackupConfigSchema,
   /** Conductor service configuration */
@@ -632,6 +668,7 @@ export const ConfigSchema = z.object({
 // Infer the types from the schemas
 export type Config = z.infer<typeof ConfigSchema>;
 export type CouchConfig = z.infer<typeof CouchConfigSchema>;
+export type CouchAuthProxyConfig = z.infer<typeof CouchAuthProxyConfigSchema>;
 export type BackupConfig = z.infer<typeof BackupConfigSchema>;
 export type MonitoringConfig = z.infer<typeof MonitoringConfigSchema>;
 export type BugMonitoringConfiguration = z.infer<

--- a/infrastructure/aws-cdk/lib/config.ts
+++ b/infrastructure/aws-cdk/lib/config.ts
@@ -381,28 +381,26 @@ const CouchConfigSchema = z.object({
 });
 
 /**
- * couch-auth-proxy (public Pouch sync ACL). Pin imageTag to the tag that
- * matches vendored `_design/acl` in @faims3/data-model (ddoc 2.3.0) and
+ * couch-auth-proxy (mandatory public Pouch sync ACL). Always deployed: ALB
+ * couch.* → proxy; Conductor INTERNAL → VPC Couch. Pin imageTag to the tag
+ * that matches vendored `_design/acl` in @faims3/data-model (ddoc 2.3.0) and
  * docker-compose.yml. See CouchAuthProxyAwsCdk.md / CouchAuthProxyCutover.md.
- *
- * `enabled: false` keeps legacy ALB → Couch (rollback only; reopens the
- * guest sync read gap). Do not enable in a live env until DATA DBs are at
- * migration v2.
  */
-const CouchAuthProxyConfigSchema = z.object({
-  /** When true, ALB couch.* → proxy; Conductor INTERNAL → VPC Couch */
-  enabled: z.boolean().default(false),
-  /** Container image repository (no tag) */
-  image: z.string().default('ghcr.io/peterbaker0/couch-auth-proxy'),
-  /** Immutable tag / digest pin (must match data-model ACL ddoc 2.3.0) */
-  imageTag: z.string().default('sha-3004091'),
-  /** Fargate CPU units */
-  cpu: z.number().int().positive().default(512),
-  /** Fargate memory in MiB */
-  memory: z.number().int().positive().default(1024),
-  /** Desired task count */
-  desiredCount: z.number().int().positive().default(2),
-});
+const CouchAuthProxyConfigSchema = z
+  .object({
+    /** Container image repository (no tag) */
+    image: z.string().default('ghcr.io/peterbaker0/couch-auth-proxy'),
+    /** Immutable tag / digest pin (must match data-model ACL ddoc 2.3.0) */
+    imageTag: z.string().default('sha-3004091'),
+    /** Fargate CPU units */
+    cpu: z.number().int().positive().default(512),
+    /** Fargate memory in MiB */
+    memory: z.number().int().positive().default(1024),
+    /** Desired task count */
+    desiredCount: z.number().int().positive().default(2),
+  })
+  // Reject legacy `enabled` and other unknown keys — proxy is always on
+  .strict();
 
 const DomainsConfigSchema = z.object({
   /** The base domain for all services. Note: Apex domains are not currently supported. */
@@ -623,11 +621,10 @@ export const ConfigSchema = z.object({
   /** CouchDB configuration */
   couch: CouchConfigSchema,
   /**
-   * Public sync ACL proxy. Optional; defaults to disabled (legacy ALB→Couch).
-   * Enable only after DATA v2 migration — see CouchAuthProxyCutover.md.
+   * Public sync ACL proxy (always deployed). Tuning/image pin only —
+   * see CouchAuthProxyCutover.md before first deploy to a live env.
    */
   couchAuthProxy: CouchAuthProxyConfigSchema.optional().default({
-    enabled: false,
     image: 'ghcr.io/peterbaker0/couch-auth-proxy',
     imageTag: 'sha-3004091',
     cpu: 512,

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -28,7 +28,6 @@ export class FaimsInfraStack extends cdk.Stack {
 
     // Pull out main config
     const config = props.config;
-    const couchAuthProxyEnabled = config.couchAuthProxy.enabled;
 
     // DNS SETUP
     // =========
@@ -99,9 +98,9 @@ export class FaimsInfraStack extends cdk.Stack {
     // COUCHDB
     // =======
 
-    // Create a single EC2 cluster which runs CouchDB.
-    // When couch-auth-proxy is enabled, stop registering Couch on the public
-    // ALB (proxy owns couch.*). DNS to the ALB stays on this construct.
+    // EC2 CouchDB is VPC-only (:5984). Public couch.* terminates on
+    // couch-auth-proxy (below). DNS alias to the shared ALB stays here.
+    // Deploy only after DATA v2 migration — see CouchAuthProxyCutover.md.
     const couchDb = new EC2CouchDB(this, 'couch-db', {
       vpc: networking.vpc,
       instanceType: config.couch.instanceType,
@@ -114,37 +113,28 @@ export class FaimsInfraStack extends cdk.Stack {
       monitoring: config.couch.monitoring,
       couchVersionTag: config.couch.couchVersionTag,
       cookieSecret: cookieSecret,
-      attachToPublicAlb: !couchAuthProxyEnabled,
     });
 
-    // COUCH-AUTH-PROXY (optional)
-    // ===========================
-    // Public Pouch sync ACL. Enable only after DATA v2 migration —
-    // see CouchAuthProxyCutover.md. Rollback: set enabled false (reopens
-    // the guest sync read gap).
+    // COUCH-AUTH-PROXY (mandatory)
+    // ============================
+    // Public Pouch sync ACL. Always on; ALB couch.* → proxy → Couch.
 
-    let couchPublicEndpoint = couchDb.couchEndpoint;
-    let couchAuthProxy: CouchAuthProxy | undefined;
-
-    if (couchAuthProxyEnabled) {
-      couchAuthProxy = new CouchAuthProxy(this, 'couch-auth-proxy', {
-        vpc: networking.vpc,
-        sharedBalancer: networking.sharedBalancer,
-        domainName: domains.couch,
-        certificate: primaryCert,
-        couchInternalUrl: couchDb.internalEndpoint,
-        couchAdminSecret: couchDb.passwordSecret,
-        couchSecurityGroup: couchDb.securityGroup,
-        corsOrigins: [`https://${domains.faims}`, `https://${domains.web}`],
-        image: config.couchAuthProxy.image,
-        imageTag: config.couchAuthProxy.imageTag,
-        cpu: config.couchAuthProxy.cpu,
-        memory: config.couchAuthProxy.memory,
-        desiredCount: config.couchAuthProxy.desiredCount,
-        couchInternalPort: couchDb.couchInternalPort,
-      });
-      couchPublicEndpoint = couchAuthProxy.publicEndpoint;
-    }
+    const couchAuthProxy = new CouchAuthProxy(this, 'couch-auth-proxy', {
+      vpc: networking.vpc,
+      sharedBalancer: networking.sharedBalancer,
+      domainName: domains.couch,
+      certificate: primaryCert,
+      couchInternalUrl: couchDb.internalEndpoint,
+      couchAdminSecret: couchDb.passwordSecret,
+      couchSecurityGroup: couchDb.securityGroup,
+      corsOrigins: [`https://${domains.faims}`, `https://${domains.web}`],
+      image: config.couchAuthProxy.image,
+      imageTag: config.couchAuthProxy.imageTag,
+      cpu: config.couchAuthProxy.cpu,
+      memory: config.couchAuthProxy.memory,
+      desiredCount: config.couchAuthProxy.desiredCount,
+      couchInternalPort: couchDb.couchInternalPort,
+    });
 
     // CONDUCTOR
     // =========
@@ -161,10 +151,8 @@ export class FaimsInfraStack extends cdk.Stack {
       rateLimiterEnabled: config.security.rateLimiterEnabled,
       authAttemptLimiterEnabled: config.security.authAttemptLimiterEnabled,
       couchDbAdminSecret: couchDb.passwordSecret,
-      couchDBPublicEndpoint: couchPublicEndpoint,
-      couchDBInternalEndpoint: couchAuthProxyEnabled
-        ? couchDb.internalEndpoint
-        : couchDb.couchEndpoint,
+      couchDBPublicEndpoint: couchAuthProxy.publicEndpoint,
+      couchDBInternalEndpoint: couchDb.internalEndpoint,
       couchDBPort: couchDb.exposedPort,
       webAppPublicUrl: `https://${domains.faims}`,
       androidAppPublicUrl: config.mobileApps.androidAppPublicUrl,
@@ -189,21 +177,18 @@ export class FaimsInfraStack extends cdk.Stack {
       bugsnagApiKey: config.bugMonitoring.bugsnagKey,
     });
 
-    // Conductor → Couch :5984 when using the VPC-internal URL (proxy mode).
-    // Legacy mode talks to Couch via the public ALB hostname.
-    if (couchAuthProxyEnabled) {
-      couchDb.securityGroup.connections.allowFrom(
-        conductor.serviceSecurityGroup,
-        ec2.Port.tcp(couchDb.couchInternalPort),
-        'Allow Conductor to CouchDB (internal)'
-      );
-    }
+    // Conductor → Couch :5984 (VPC-internal admin path)
+    couchDb.securityGroup.connections.allowFrom(
+      conductor.serviceSecurityGroup,
+      ec2.Port.tcp(couchDb.couchInternalPort),
+      'Allow Conductor to CouchDB (internal)'
+    );
 
     // FRONT-END
     // =========
 
     // Deploy the FAIMS 3 web front-end (app, web, docs) as S3 + CloudFront static websites
-    // CSP keep https://couch.* — hostname unchanged whether proxy or legacy.
+    // CSP keep https://couch.* — same hostname, terminated on the proxy.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _frontEnd = new FaimsFrontEnd(this, 'frontend', {
       couchDbDomainOnly: domains.couch,

--- a/infrastructure/aws-cdk/lib/faims-infra-stack.ts
+++ b/infrastructure/aws-cdk/lib/faims-infra-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as sm from 'aws-cdk-lib/aws-secretsmanager';
 import {BackupConstruct} from './components/backups';
 import {Construct} from 'constructs';
@@ -8,6 +9,7 @@ import {FaimsConductor} from './components/conductor';
 import {FaimsFrontEnd} from './components/front-end';
 import {FaimsNetworking} from './components/networking';
 import {EC2CouchDB} from './components/couch-db';
+import {CouchAuthProxy} from './components/couch-auth-proxy';
 import {Config} from './config';
 
 /**
@@ -26,6 +28,7 @@ export class FaimsInfraStack extends cdk.Stack {
 
     // Pull out main config
     const config = props.config;
+    const couchAuthProxyEnabled = config.couchAuthProxy.enabled;
 
     // DNS SETUP
     // =========
@@ -96,7 +99,9 @@ export class FaimsInfraStack extends cdk.Stack {
     // COUCHDB
     // =======
 
-    // Create a single EC2 cluster which runs CouchDB
+    // Create a single EC2 cluster which runs CouchDB.
+    // When couch-auth-proxy is enabled, stop registering Couch on the public
+    // ALB (proxy owns couch.*). DNS to the ALB stays on this construct.
     const couchDb = new EC2CouchDB(this, 'couch-db', {
       vpc: networking.vpc,
       instanceType: config.couch.instanceType,
@@ -109,7 +114,37 @@ export class FaimsInfraStack extends cdk.Stack {
       monitoring: config.couch.monitoring,
       couchVersionTag: config.couch.couchVersionTag,
       cookieSecret: cookieSecret,
+      attachToPublicAlb: !couchAuthProxyEnabled,
     });
+
+    // COUCH-AUTH-PROXY (optional)
+    // ===========================
+    // Public Pouch sync ACL. Enable only after DATA v2 migration —
+    // see CouchAuthProxyCutover.md. Rollback: set enabled false (reopens
+    // the guest sync read gap).
+
+    let couchPublicEndpoint = couchDb.couchEndpoint;
+    let couchAuthProxy: CouchAuthProxy | undefined;
+
+    if (couchAuthProxyEnabled) {
+      couchAuthProxy = new CouchAuthProxy(this, 'couch-auth-proxy', {
+        vpc: networking.vpc,
+        sharedBalancer: networking.sharedBalancer,
+        domainName: domains.couch,
+        certificate: primaryCert,
+        couchInternalUrl: couchDb.internalEndpoint,
+        couchAdminSecret: couchDb.passwordSecret,
+        couchSecurityGroup: couchDb.securityGroup,
+        corsOrigins: [`https://${domains.faims}`, `https://${domains.web}`],
+        image: config.couchAuthProxy.image,
+        imageTag: config.couchAuthProxy.imageTag,
+        cpu: config.couchAuthProxy.cpu,
+        memory: config.couchAuthProxy.memory,
+        desiredCount: config.couchAuthProxy.desiredCount,
+        couchInternalPort: couchDb.couchInternalPort,
+      });
+      couchPublicEndpoint = couchAuthProxy.publicEndpoint;
+    }
 
     // CONDUCTOR
     // =========
@@ -126,7 +161,10 @@ export class FaimsInfraStack extends cdk.Stack {
       rateLimiterEnabled: config.security.rateLimiterEnabled,
       authAttemptLimiterEnabled: config.security.authAttemptLimiterEnabled,
       couchDbAdminSecret: couchDb.passwordSecret,
-      couchDBEndpoint: couchDb.couchEndpoint,
+      couchDBPublicEndpoint: couchPublicEndpoint,
+      couchDBInternalEndpoint: couchAuthProxyEnabled
+        ? couchDb.internalEndpoint
+        : couchDb.couchEndpoint,
       couchDBPort: couchDb.exposedPort,
       webAppPublicUrl: `https://${domains.faims}`,
       androidAppPublicUrl: config.mobileApps.androidAppPublicUrl,
@@ -151,10 +189,21 @@ export class FaimsInfraStack extends cdk.Stack {
       bugsnagApiKey: config.bugMonitoring.bugsnagKey,
     });
 
+    // Conductor → Couch :5984 when using the VPC-internal URL (proxy mode).
+    // Legacy mode talks to Couch via the public ALB hostname.
+    if (couchAuthProxyEnabled) {
+      couchDb.securityGroup.connections.allowFrom(
+        conductor.serviceSecurityGroup,
+        ec2.Port.tcp(couchDb.couchInternalPort),
+        'Allow Conductor to CouchDB (internal)'
+      );
+    }
+
     // FRONT-END
     // =========
 
     // Deploy the FAIMS 3 web front-end (app, web, docs) as S3 + CloudFront static websites
+    // CSP keep https://couch.* — hostname unchanged whether proxy or legacy.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _frontEnd = new FaimsFrontEnd(this, 'frontend', {
       couchDbDomainOnly: domains.couch,

--- a/infrastructure/aws-cdk/test/config.test.ts
+++ b/infrastructure/aws-cdk/test/config.test.ts
@@ -3,7 +3,7 @@
  * key rules (MapTiler key required in one of two places when source is MAPTILER).
  */
 import {ZodError} from 'zod';
-import {UiConfiguration} from '../lib/config';
+import {ConfigSchema, UiConfiguration} from '../lib/config';
 
 function minimalOfflineMaps(
   overrides: {
@@ -115,5 +115,121 @@ describe('UiConfiguration addressAutosuggest + MapTiler key validation', () => {
       addressAutosuggest: {source: 'MAPTILER', maptilerKey: '   '},
     });
     expect(() => UiConfiguration.parse(config)).not.toThrow();
+  });
+});
+
+function minimalStackConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    stackName: 'TestStack',
+    hostedZone: {id: 'Z123', name: 'example.com'},
+    certificates: {
+      primary: 'arn:aws:acm:ap-southeast-2:123456789012:certificate/abc',
+      cloudfront: 'arn:aws:acm:us-east-1:123456789012:certificate/def',
+    },
+    aws: {account: '123456789012', region: 'ap-southeast-2'},
+    secrets: {
+      privateKey:
+        'arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:pk',
+      publicKey:
+        'arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:pub',
+    },
+    uiConfiguration: minimalUiConfig(),
+    supportLinks: {
+      supportEmail: 'support@example.com',
+      privacyPolicyUrl: 'https://example.com/privacy',
+      contactUrl: 'https://example.com/contact',
+    },
+    couch: {
+      volumeSize: 20,
+      instanceType: 't3.small',
+    },
+    backup: {
+      vaultName: 'test-vault',
+      retentionDays: 30,
+      scheduleExpression: 'cron(0 3 * * ? *)',
+    },
+    conductor: {
+      name: 'Test',
+      description: 'Test conductor',
+      conductorDockerImage: 'ghcr.io/faims/faims3-api',
+      cpu: 512,
+      memory: 1024,
+      autoScaling: {
+        desiredCapacity: 1,
+        minCapacity: 1,
+        maxCapacity: 2,
+        targetCpuUtilization: 70,
+        targetMemoryUtilization: 70,
+        scaleInCooldown: 60,
+        scaleOutCooldown: 60,
+      },
+    },
+    domains: {baseDomain: 'example.com'},
+    mobileApps: {
+      androidAppPublicUrl: 'https://play.google.com/store/apps/details?id=x',
+      iosAppPublicUrl: 'https://apps.apple.com/app/x',
+    },
+    web: {title: 'Control Centre'},
+    smtp: {
+      emailServiceType: 'SMTP',
+      fromEmail: 'notify@example.com',
+      fromName: 'FAIMS',
+      testEmailAddress: 'admin@example.com',
+      credentialsSecretArn:
+        'arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:smtp',
+    },
+    bugMonitoring: {},
+    ...overrides,
+  };
+}
+
+describe('ConfigSchema couchAuthProxy', () => {
+  it('defaults to disabled when couchAuthProxy is omitted', () => {
+    const parsed = ConfigSchema.parse(minimalStackConfig());
+    expect(parsed.couchAuthProxy.enabled).toBe(false);
+    expect(parsed.couchAuthProxy.imageTag).toBe('sha-3004091');
+    expect(parsed.couchAuthProxy.image).toBe(
+      'ghcr.io/peterbaker0/couch-auth-proxy'
+    );
+  });
+
+  it('accepts enabled proxy config with defaults for cpu/memory/count', () => {
+    const parsed = ConfigSchema.parse(
+      minimalStackConfig({
+        couchAuthProxy: {enabled: true},
+      })
+    );
+    expect(parsed.couchAuthProxy.enabled).toBe(true);
+    expect(parsed.couchAuthProxy.cpu).toBe(512);
+    expect(parsed.couchAuthProxy.memory).toBe(1024);
+    expect(parsed.couchAuthProxy.desiredCount).toBe(2);
+    expect(parsed.couchAuthProxy.imageTag).toBe('sha-3004091');
+  });
+
+  it('accepts a custom image pin', () => {
+    const parsed = ConfigSchema.parse(
+      minimalStackConfig({
+        couchAuthProxy: {
+          enabled: true,
+          image: 'ghcr.io/peterbaker0/couch-auth-proxy',
+          imageTag: 'sha-deadbeef',
+          cpu: 256,
+          memory: 512,
+          desiredCount: 1,
+        },
+      })
+    );
+    expect(parsed.couchAuthProxy.imageTag).toBe('sha-deadbeef');
+    expect(parsed.couchAuthProxy.cpu).toBe(256);
+  });
+
+  it('rejects non-positive cpu', () => {
+    expect(() =>
+      ConfigSchema.parse(
+        minimalStackConfig({
+          couchAuthProxy: {enabled: true, cpu: 0},
+        })
+      )
+    ).toThrow(ZodError);
   });
 });

--- a/infrastructure/aws-cdk/test/config.test.ts
+++ b/infrastructure/aws-cdk/test/config.test.ts
@@ -184,25 +184,24 @@ function minimalStackConfig(overrides: Record<string, unknown> = {}) {
 }
 
 describe('ConfigSchema couchAuthProxy', () => {
-  it('defaults to disabled when couchAuthProxy is omitted', () => {
+  it('applies defaults when couchAuthProxy is omitted', () => {
     const parsed = ConfigSchema.parse(minimalStackConfig());
-    expect(parsed.couchAuthProxy.enabled).toBe(false);
     expect(parsed.couchAuthProxy.imageTag).toBe('sha-3004091');
     expect(parsed.couchAuthProxy.image).toBe(
       'ghcr.io/peterbaker0/couch-auth-proxy'
     );
-  });
-
-  it('accepts enabled proxy config with defaults for cpu/memory/count', () => {
-    const parsed = ConfigSchema.parse(
-      minimalStackConfig({
-        couchAuthProxy: {enabled: true},
-      })
-    );
-    expect(parsed.couchAuthProxy.enabled).toBe(true);
     expect(parsed.couchAuthProxy.cpu).toBe(512);
     expect(parsed.couchAuthProxy.memory).toBe(1024);
     expect(parsed.couchAuthProxy.desiredCount).toBe(2);
+  });
+
+  it('accepts an empty object and fills image/cpu defaults', () => {
+    const parsed = ConfigSchema.parse(
+      minimalStackConfig({
+        couchAuthProxy: {},
+      })
+    );
+    expect(parsed.couchAuthProxy.cpu).toBe(512);
     expect(parsed.couchAuthProxy.imageTag).toBe('sha-3004091');
   });
 
@@ -210,7 +209,6 @@ describe('ConfigSchema couchAuthProxy', () => {
     const parsed = ConfigSchema.parse(
       minimalStackConfig({
         couchAuthProxy: {
-          enabled: true,
           image: 'ghcr.io/peterbaker0/couch-auth-proxy',
           imageTag: 'sha-deadbeef',
           cpu: 256,
@@ -227,7 +225,17 @@ describe('ConfigSchema couchAuthProxy', () => {
     expect(() =>
       ConfigSchema.parse(
         minimalStackConfig({
-          couchAuthProxy: {enabled: true, cpu: 0},
+          couchAuthProxy: {cpu: 0},
+        })
+      )
+    ).toThrow(ZodError);
+  });
+
+  it('rejects unknown enabled flag (proxy is always on)', () => {
+    expect(() =>
+      ConfigSchema.parse(
+        minimalStackConfig({
+          couchAuthProxy: {enabled: false},
         })
       )
     ).toThrow(ZodError);

--- a/infrastructure/aws-cdk/test/couch-auth-proxy.synth.test.ts
+++ b/infrastructure/aws-cdk/test/couch-auth-proxy.synth.test.ts
@@ -1,7 +1,6 @@
 /**
- * Synth-level assertions for couch-auth-proxy cutover wiring.
- * Uses a minimal stack (no frontend bundling) so CI can verify ALB / env / SG
- * behaviour with couchAuthProxy.enabled true and false.
+ * Synth-level assertions for mandatory couch-auth-proxy wiring.
+ * Uses a minimal stack (no frontend bundling) so CI can verify ALB / env / SG.
  */
 import * as cdk from 'aws-cdk-lib';
 import {Match, Template} from 'aws-cdk-lib/assertions';
@@ -14,9 +13,9 @@ import {FaimsConductor} from '../lib/components/conductor';
 import {FaimsNetworking} from '../lib/components/networking';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
-function wireMinimalStack(proxyEnabled: boolean): Template {
+function wireMinimalStack(): Template {
   const app = new cdk.App();
-  const stack = new cdk.Stack(app, proxyEnabled ? 'ProxyOn' : 'ProxyOff', {
+  const stack = new cdk.Stack(app, 'ProxyStack', {
     env: {account: '123456789012', region: 'ap-southeast-2'},
   });
 
@@ -49,31 +48,24 @@ function wireMinimalStack(proxyEnabled: boolean): Template {
     dataVolumeSize: 20,
     couchVersionTag: '3.3.3',
     cookieSecret,
-    attachToPublicAlb: !proxyEnabled,
   });
 
-  let couchPublicEndpoint = couchDb.couchEndpoint;
-  if (proxyEnabled) {
-    const proxy = new CouchAuthProxy(stack, 'couch-auth-proxy', {
-      vpc: networking.vpc,
-      sharedBalancer: networking.sharedBalancer,
-      domainName: domainCouch,
-      certificate: cert,
-      couchInternalUrl: couchDb.internalEndpoint,
-      couchAdminSecret: couchDb.passwordSecret,
-      couchSecurityGroup: couchDb.securityGroup,
-      corsOrigins: ['https://faims.example.com', 'https://web.example.com'],
-      image: 'ghcr.io/peterbaker0/couch-auth-proxy',
-      imageTag: 'sha-3004091',
-      cpu: 512,
-      memory: 1024,
-      desiredCount: 2,
-      couchInternalPort: couchDb.couchInternalPort,
-    });
-    couchPublicEndpoint = proxy.publicEndpoint;
-
-    // Conductor SG wired below after construct exists
-  }
+  const proxy = new CouchAuthProxy(stack, 'couch-auth-proxy', {
+    vpc: networking.vpc,
+    sharedBalancer: networking.sharedBalancer,
+    domainName: domainCouch,
+    certificate: cert,
+    couchInternalUrl: couchDb.internalEndpoint,
+    couchAdminSecret: couchDb.passwordSecret,
+    couchSecurityGroup: couchDb.securityGroup,
+    corsOrigins: ['https://faims.example.com', 'https://web.example.com'],
+    image: 'ghcr.io/peterbaker0/couch-auth-proxy',
+    imageTag: 'sha-3004091',
+    cpu: 512,
+    memory: 1024,
+    desiredCount: 2,
+    couchInternalPort: couchDb.couchInternalPort,
+  });
 
   const conductor = new FaimsConductor(stack, 'conductor', {
     vpc: networking.vpc,
@@ -83,10 +75,8 @@ function wireMinimalStack(proxyEnabled: boolean): Template {
       'arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:pk-AbCdEf',
     hz,
     couchDbAdminSecret: couchDb.passwordSecret,
-    couchDBPublicEndpoint: couchPublicEndpoint,
-    couchDBInternalEndpoint: proxyEnabled
-      ? couchDb.internalEndpoint
-      : couchDb.couchEndpoint,
+    couchDBPublicEndpoint: proxy.publicEndpoint,
+    couchDBInternalEndpoint: couchDb.internalEndpoint,
     couchDBPort: couchDb.exposedPort,
     webAppPublicUrl: 'https://faims.example.com',
     androidAppPublicUrl: 'https://play.google.com/store/apps/details?id=x',
@@ -127,156 +117,96 @@ function wireMinimalStack(proxyEnabled: boolean): Template {
     localhostWhitelist: false,
   });
 
-  if (proxyEnabled) {
-    couchDb.securityGroup.connections.allowFrom(
-      conductor.serviceSecurityGroup,
-      ec2.Port.tcp(couchDb.couchInternalPort),
-      'Allow Conductor to CouchDB (internal)'
-    );
-  }
+  couchDb.securityGroup.connections.allowFrom(
+    conductor.serviceSecurityGroup,
+    ec2.Port.tcp(couchDb.couchInternalPort),
+    'Allow Conductor to CouchDB (internal)'
+  );
 
   return Template.fromStack(stack);
 }
 
-describe('couch-auth-proxy CDK wiring', () => {
-  describe('enabled: true', () => {
-    const template = wireMinimalStack(true);
+describe('couch-auth-proxy CDK wiring (always on)', () => {
+  const template = wireMinimalStack();
 
-    it('registers ALB host rule to proxy TG health path, not Couch :5984', () => {
-      // Proxy target group health check
-      template.hasResourceProperties(
-        'AWS::ElasticLoadBalancingV2::TargetGroup',
-        {
-          Port: 8000,
-          HealthCheckPath: '/_couch-auth-proxy/health',
-          Matcher: {HttpCode: '200'},
-        }
-      );
-
-      // No instance TG on Couch :5984 when proxy owns the host
-      const tgs = template.findResources(
-        'AWS::ElasticLoadBalancingV2::TargetGroup'
-      );
-      const couchInstanceTg = Object.values(tgs).filter(
-        (tg: {Properties?: {Port?: number; TargetType?: string}}) =>
-          tg.Properties?.Port === 5984 &&
-          tg.Properties?.TargetType === 'instance'
-      );
-      expect(couchInstanceTg).toHaveLength(0);
+  it('registers ALB host rule to proxy TG health path, not Couch :5984', () => {
+    template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
+      Port: 8000,
+      HealthCheckPath: '/_couch-auth-proxy/health',
+      Matcher: {HttpCode: '200'},
     });
 
-    it('runs proxy Fargate task with hardened ACL env and Secrets Manager admin', () => {
-      template.hasResourceProperties('AWS::ECS::TaskDefinition', {
-        ContainerDefinitions: Match.arrayWith([
-          Match.objectLike({
-            Image: 'ghcr.io/peterbaker0/couch-auth-proxy:sha-3004091',
-            Environment: Match.arrayWith([
-              {Name: 'ACL_DB_INCLUDE', Value: '/^data-/'},
-              {
-                Name: 'ACL_ROUTE_INCLUDE',
-                Value: 'pouch-sync,session',
-              },
-              {Name: 'ACL_AUTO_INSTALL', Value: 'false'},
-              {
-                Name: 'AUTH_RESOLVE_VIA_COUCH_SESSION',
-                Value: 'true',
-              },
-              {
-                Name: 'CORS_ORIGINS',
-                Value: 'https://faims.example.com,https://web.example.com',
-              },
-            ]),
-            Secrets: Match.arrayWith([
-              Match.objectLike({Name: 'COUCH_ADMIN_USER'}),
-              Match.objectLike({Name: 'COUCH_ADMIN_PASSWORD'}),
-            ]),
-          }),
-        ]),
-      });
-    });
+    const tgs = template.findResources(
+      'AWS::ElasticLoadBalancingV2::TargetGroup'
+    );
+    const couchInstanceTg = Object.values(tgs).filter(
+      (tg: {Properties?: {Port?: number; TargetType?: string}}) =>
+        tg.Properties?.Port === 5984 && tg.Properties?.TargetType === 'instance'
+    );
+    expect(couchInstanceTg).toHaveLength(0);
+  });
 
-    it('sets Conductor PUBLIC vs INTERNAL Couch URLs distinctly', () => {
-      const tasks = template.findResources('AWS::ECS::TaskDefinition');
-      const conductor = Object.values(tasks).find(
-        (td: {
-          Properties?: {
-            ContainerDefinitions?: Array<{
-              Image?: string;
-              Environment?: Array<{Name: string; Value: unknown}>;
-            }>;
-          };
-        }) =>
-          td.Properties?.ContainerDefinitions?.some(c =>
-            c.Image?.includes('faims3-api')
-          )
-      ) as {
-        Properties: {
-          ContainerDefinitions: Array<{
+  it('runs proxy Fargate task with hardened ACL env and Secrets Manager admin', () => {
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Image: 'ghcr.io/peterbaker0/couch-auth-proxy:sha-3004091',
+          Environment: Match.arrayWith([
+            {Name: 'ACL_DB_INCLUDE', Value: '/^data-/'},
+            {
+              Name: 'ACL_ROUTE_INCLUDE',
+              Value: 'pouch-sync,session',
+            },
+            {Name: 'ACL_AUTO_INSTALL', Value: 'false'},
+            {
+              Name: 'AUTH_RESOLVE_VIA_COUCH_SESSION',
+              Value: 'true',
+            },
+            {
+              Name: 'CORS_ORIGINS',
+              Value: 'https://faims.example.com,https://web.example.com',
+            },
+          ]),
+          Secrets: Match.arrayWith([
+            Match.objectLike({Name: 'COUCH_ADMIN_USER'}),
+            Match.objectLike({Name: 'COUCH_ADMIN_PASSWORD'}),
+          ]),
+        }),
+      ]),
+    });
+  });
+
+  it('sets Conductor PUBLIC vs INTERNAL Couch URLs distinctly', () => {
+    const tasks = template.findResources('AWS::ECS::TaskDefinition');
+    const conductor = Object.values(tasks).find(
+      (td: {
+        Properties?: {
+          ContainerDefinitions?: Array<{
             Image?: string;
             Environment?: Array<{Name: string; Value: unknown}>;
           }>;
         };
+      }) =>
+        td.Properties?.ContainerDefinitions?.some(c =>
+          c.Image?.includes('faims3-api')
+        )
+    ) as {
+      Properties: {
+        ContainerDefinitions: Array<{
+          Image?: string;
+          Environment?: Array<{Name: string; Value: unknown}>;
+        }>;
       };
-      const env = conductor.Properties.ContainerDefinitions.find(c =>
-        c.Image?.includes('faims3-api')
-      )!.Environment!;
-      const byName = Object.fromEntries(env.map(e => [e.Name, e.Value]));
-      expect(byName.COUCHDB_PUBLIC_URL).toBe('https://couch.example.com:443');
-      // INTERNAL must be VPC HTTP :5984 (CFN Fn::Join over private IP), not public HTTPS
-      expect(byName.COUCHDB_INTERNAL_URL).not.toBe(byName.COUCHDB_PUBLIC_URL);
-      const internal = JSON.stringify(byName.COUCHDB_INTERNAL_URL);
-      expect(internal).toContain('http://');
-      expect(internal).toContain(':5984');
-      expect(internal).not.toContain('https://');
-    });
-  });
-
-  describe('enabled: false (legacy rollback)', () => {
-    const template = wireMinimalStack(false);
-
-    it('keeps ALB → Couch instance TG on :5984', () => {
-      template.hasResourceProperties(
-        'AWS::ElasticLoadBalancingV2::TargetGroup',
-        {
-          Port: 5984,
-          TargetType: 'instance',
-        }
-      );
-    });
-
-    it('does not create a couch-auth-proxy task definition', () => {
-      const tasks = template.findResources('AWS::ECS::TaskDefinition');
-      const proxyTasks = Object.values(tasks).filter(
-        (td: {
-          Properties?: {
-            ContainerDefinitions?: Array<{Image?: string}>;
-          };
-        }) =>
-          td.Properties?.ContainerDefinitions?.some(c =>
-            c.Image?.includes('couch-auth-proxy')
-          )
-      );
-      expect(proxyTasks).toHaveLength(0);
-    });
-
-    it('keeps Conductor PUBLIC and INTERNAL on the same public Couch URL', () => {
-      template.hasResourceProperties('AWS::ECS::TaskDefinition', {
-        ContainerDefinitions: Match.arrayWith([
-          Match.objectLike({
-            Image: Match.stringLikeRegexp('faims3-api'),
-            Environment: Match.arrayWith([
-              {
-                Name: 'COUCHDB_PUBLIC_URL',
-                Value: 'https://couch.example.com:443',
-              },
-              {
-                Name: 'COUCHDB_INTERNAL_URL',
-                Value: 'https://couch.example.com:443',
-              },
-            ]),
-          }),
-        ]),
-      });
-    });
+    };
+    const env = conductor.Properties.ContainerDefinitions.find(c =>
+      c.Image?.includes('faims3-api')
+    )!.Environment!;
+    const byName = Object.fromEntries(env.map(e => [e.Name, e.Value]));
+    expect(byName.COUCHDB_PUBLIC_URL).toBe('https://couch.example.com:443');
+    expect(byName.COUCHDB_INTERNAL_URL).not.toBe(byName.COUCHDB_PUBLIC_URL);
+    const internal = JSON.stringify(byName.COUCHDB_INTERNAL_URL);
+    expect(internal).toContain('http://');
+    expect(internal).toContain(':5984');
+    expect(internal).not.toContain('https://');
   });
 });

--- a/infrastructure/aws-cdk/test/couch-auth-proxy.synth.test.ts
+++ b/infrastructure/aws-cdk/test/couch-auth-proxy.synth.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Synth-level assertions for couch-auth-proxy cutover wiring.
+ * Uses a minimal stack (no frontend bundling) so CI can verify ALB / env / SG
+ * behaviour with couchAuthProxy.enabled true and false.
+ */
+import * as cdk from 'aws-cdk-lib';
+import {Match, Template} from 'aws-cdk-lib/assertions';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
+import {EC2CouchDB} from '../lib/components/couch-db';
+import {CouchAuthProxy} from '../lib/components/couch-auth-proxy';
+import {FaimsConductor} from '../lib/components/conductor';
+import {FaimsNetworking} from '../lib/components/networking';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+
+function wireMinimalStack(proxyEnabled: boolean): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, proxyEnabled ? 'ProxyOn' : 'ProxyOff', {
+    env: {account: '123456789012', region: 'ap-southeast-2'},
+  });
+
+  const hz = route53.HostedZone.fromHostedZoneAttributes(stack, 'hz', {
+    hostedZoneId: 'Z1234567890',
+    zoneName: 'example.com',
+  });
+  const cert = acm.Certificate.fromCertificateArn(
+    stack,
+    'cert',
+    'arn:aws:acm:ap-southeast-2:123456789012:certificate/11111111-1111-1111-1111-111111111111'
+  );
+  const networking = new FaimsNetworking(stack, 'networking', {
+    certificate: cert,
+  });
+  const cookieSecret = new sm.Secret(stack, 'cookie', {
+    generateSecretString: {passwordLength: 16, excludePunctuation: true},
+  });
+
+  const domainCouch = 'couch.example.com';
+  const domainConductor = 'conductor.example.com';
+
+  const couchDb = new EC2CouchDB(stack, 'couch-db', {
+    vpc: networking.vpc,
+    instanceType: 't3.small',
+    certificate: cert,
+    domainName: domainCouch,
+    hz,
+    sharedBalancer: networking.sharedBalancer,
+    dataVolumeSize: 20,
+    couchVersionTag: '3.3.3',
+    cookieSecret,
+    attachToPublicAlb: !proxyEnabled,
+  });
+
+  let couchPublicEndpoint = couchDb.couchEndpoint;
+  if (proxyEnabled) {
+    const proxy = new CouchAuthProxy(stack, 'couch-auth-proxy', {
+      vpc: networking.vpc,
+      sharedBalancer: networking.sharedBalancer,
+      domainName: domainCouch,
+      certificate: cert,
+      couchInternalUrl: couchDb.internalEndpoint,
+      couchAdminSecret: couchDb.passwordSecret,
+      couchSecurityGroup: couchDb.securityGroup,
+      corsOrigins: ['https://faims.example.com', 'https://web.example.com'],
+      image: 'ghcr.io/peterbaker0/couch-auth-proxy',
+      imageTag: 'sha-3004091',
+      cpu: 512,
+      memory: 1024,
+      desiredCount: 2,
+      couchInternalPort: couchDb.couchInternalPort,
+    });
+    couchPublicEndpoint = proxy.publicEndpoint;
+
+    // Conductor SG wired below after construct exists
+  }
+
+  const conductor = new FaimsConductor(stack, 'conductor', {
+    vpc: networking.vpc,
+    certificate: cert,
+    domainName: domainConductor,
+    privateKeySecretArn:
+      'arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:pk-AbCdEf',
+    hz,
+    couchDbAdminSecret: couchDb.passwordSecret,
+    couchDBPublicEndpoint: couchPublicEndpoint,
+    couchDBInternalEndpoint: proxyEnabled
+      ? couchDb.internalEndpoint
+      : couchDb.couchEndpoint,
+    couchDBPort: couchDb.exposedPort,
+    webAppPublicUrl: 'https://faims.example.com',
+    androidAppPublicUrl: 'https://play.google.com/store/apps/details?id=x',
+    iosAppPublicUrl: 'https://apps.apple.com/app/x',
+    appId: 'FAIMS',
+    sharedBalancer: networking.sharedBalancer,
+    config: {
+      name: 'Test',
+      description: 'Test',
+      conductorDockerImage: 'ghcr.io/faims/faims3-api',
+      conductorDockerImageTag: 'latest',
+      shortCodePrefix: 'FAIMS',
+      provisionSSOUsersPolicy: 'reject',
+      cpu: 512,
+      memory: 1024,
+      localhostWhitelist: false,
+      migrateNotebooksOnStartup: true,
+      autoScaling: {
+        desiredCapacity: 1,
+        minCapacity: 1,
+        maxCapacity: 2,
+        targetCpuUtilization: 70,
+        targetMemoryUtilization: 70,
+        scaleInCooldown: 60,
+        scaleOutCooldown: 60,
+      },
+    },
+    cookieSecret,
+    webUrl: 'https://web.example.com',
+    smtpCredsArn:
+      'arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:smtp-AbCdEf',
+    smtpConfig: {
+      emailServiceType: 'SMTP',
+      fromEmail: 'notify@example.com',
+      fromName: 'FAIMS',
+      testEmailAddress: 'admin@example.com',
+    },
+    localhostWhitelist: false,
+  });
+
+  if (proxyEnabled) {
+    couchDb.securityGroup.connections.allowFrom(
+      conductor.serviceSecurityGroup,
+      ec2.Port.tcp(couchDb.couchInternalPort),
+      'Allow Conductor to CouchDB (internal)'
+    );
+  }
+
+  return Template.fromStack(stack);
+}
+
+describe('couch-auth-proxy CDK wiring', () => {
+  describe('enabled: true', () => {
+    const template = wireMinimalStack(true);
+
+    it('registers ALB host rule to proxy TG health path, not Couch :5984', () => {
+      // Proxy target group health check
+      template.hasResourceProperties(
+        'AWS::ElasticLoadBalancingV2::TargetGroup',
+        {
+          Port: 8000,
+          HealthCheckPath: '/_couch-auth-proxy/health',
+          Matcher: {HttpCode: '200'},
+        }
+      );
+
+      // No instance TG on Couch :5984 when proxy owns the host
+      const tgs = template.findResources(
+        'AWS::ElasticLoadBalancingV2::TargetGroup'
+      );
+      const couchInstanceTg = Object.values(tgs).filter(
+        (tg: {Properties?: {Port?: number; TargetType?: string}}) =>
+          tg.Properties?.Port === 5984 &&
+          tg.Properties?.TargetType === 'instance'
+      );
+      expect(couchInstanceTg).toHaveLength(0);
+    });
+
+    it('runs proxy Fargate task with hardened ACL env and Secrets Manager admin', () => {
+      template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Image: 'ghcr.io/peterbaker0/couch-auth-proxy:sha-3004091',
+            Environment: Match.arrayWith([
+              {Name: 'ACL_DB_INCLUDE', Value: '/^data-/'},
+              {
+                Name: 'ACL_ROUTE_INCLUDE',
+                Value: 'pouch-sync,session',
+              },
+              {Name: 'ACL_AUTO_INSTALL', Value: 'false'},
+              {
+                Name: 'AUTH_RESOLVE_VIA_COUCH_SESSION',
+                Value: 'true',
+              },
+              {
+                Name: 'CORS_ORIGINS',
+                Value: 'https://faims.example.com,https://web.example.com',
+              },
+            ]),
+            Secrets: Match.arrayWith([
+              Match.objectLike({Name: 'COUCH_ADMIN_USER'}),
+              Match.objectLike({Name: 'COUCH_ADMIN_PASSWORD'}),
+            ]),
+          }),
+        ]),
+      });
+    });
+
+    it('sets Conductor PUBLIC vs INTERNAL Couch URLs distinctly', () => {
+      const tasks = template.findResources('AWS::ECS::TaskDefinition');
+      const conductor = Object.values(tasks).find(
+        (td: {
+          Properties?: {
+            ContainerDefinitions?: Array<{
+              Image?: string;
+              Environment?: Array<{Name: string; Value: unknown}>;
+            }>;
+          };
+        }) =>
+          td.Properties?.ContainerDefinitions?.some(c =>
+            c.Image?.includes('faims3-api')
+          )
+      ) as {
+        Properties: {
+          ContainerDefinitions: Array<{
+            Image?: string;
+            Environment?: Array<{Name: string; Value: unknown}>;
+          }>;
+        };
+      };
+      const env = conductor.Properties.ContainerDefinitions.find(c =>
+        c.Image?.includes('faims3-api')
+      )!.Environment!;
+      const byName = Object.fromEntries(env.map(e => [e.Name, e.Value]));
+      expect(byName.COUCHDB_PUBLIC_URL).toBe('https://couch.example.com:443');
+      // INTERNAL must be VPC HTTP :5984 (CFN Fn::Join over private IP), not public HTTPS
+      expect(byName.COUCHDB_INTERNAL_URL).not.toBe(byName.COUCHDB_PUBLIC_URL);
+      const internal = JSON.stringify(byName.COUCHDB_INTERNAL_URL);
+      expect(internal).toContain('http://');
+      expect(internal).toContain(':5984');
+      expect(internal).not.toContain('https://');
+    });
+  });
+
+  describe('enabled: false (legacy rollback)', () => {
+    const template = wireMinimalStack(false);
+
+    it('keeps ALB → Couch instance TG on :5984', () => {
+      template.hasResourceProperties(
+        'AWS::ElasticLoadBalancingV2::TargetGroup',
+        {
+          Port: 5984,
+          TargetType: 'instance',
+        }
+      );
+    });
+
+    it('does not create a couch-auth-proxy task definition', () => {
+      const tasks = template.findResources('AWS::ECS::TaskDefinition');
+      const proxyTasks = Object.values(tasks).filter(
+        (td: {
+          Properties?: {
+            ContainerDefinitions?: Array<{Image?: string}>;
+          };
+        }) =>
+          td.Properties?.ContainerDefinitions?.some(c =>
+            c.Image?.includes('couch-auth-proxy')
+          )
+      );
+      expect(proxyTasks).toHaveLength(0);
+    });
+
+    it('keeps Conductor PUBLIC and INTERNAL on the same public Couch URL', () => {
+      template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Image: Match.stringLikeRegexp('faims3-api'),
+            Environment: Match.arrayWith([
+              {
+                Name: 'COUCHDB_PUBLIC_URL',
+                Value: 'https://couch.example.com:443',
+              },
+              {
+                Name: 'COUCHDB_INTERNAL_URL',
+                Value: 'https://couch.example.com:443',
+              },
+            ]),
+          }),
+        ]),
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the AWS CDK design in `CouchAuthProxyAwsCdk.md` so public Pouch sync is ACL-filtered and CouchDB is not on the internet-facing ALB.

Stacked on `feat/proxy-auth-integration` (PR #20). **Do not merge to main or deploy to a live env without #20’s app/migration work and DATA v2 backfill** — see `CouchAuthProxyCutover.md`.

The proxy is **mandatory** (no `couchAuthProxy.enabled` flag). Config only tunes image/cpu/memory/desiredCount.

### Topology

```
Internet → ALB couch.* → ECS Fargate couch-auth-proxy :8000
                              ↓ (SG)
                         EC2 CouchDB :5984
                              ↑ (SG)
                         ECS Conductor (admin Basic, internal URL)
```

### Changes

- Zod `couchAuthProxy` config + `configs/sample.json` (image pin `sha-3004091` / ddoc 2.3.0); `.strict()` rejects legacy `enabled`
- `CouchAuthProxy` ECS Fargate construct (health `/_couch-auth-proxy/health`, hardened ACL env, Secrets Manager admin)
- `EC2CouchDB`: exports `securityGroup` + `internalEndpoint`; never registers Couch on the public ALB
- `FaimsConductor`: always distinct `couchDBPublicEndpoint` / `couchDBInternalEndpoint`
- Stack SG wiring: proxy + Conductor → `:5984` only; CSP hostname unchanged
- README + DeployingAWSStack + design doc updates
- Synth-level Jest tests for always-on wiring

## Test plan

- [x] `pnpm run validate-config` with updated sample
- [x] `pnpm test` in `infrastructure/aws-cdk`
- [x] `pnpm run typecheck` / lint
- [ ] Operator: `cdk diff` on a non-prod account
- [ ] Operator: DATA v2 migration before production sync traffic hits the proxy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25cdec68-f1a5-4b62-a592-54cc4ef2c2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25cdec68-f1a5-4b62-a592-54cc4ef2c2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

